### PR TITLE
Blender 5.0 compatibility, viewport helpers, and multi-wheel configs (v1.0.0 -> v1.4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,100 +5,154 @@
 
 # True RoboAnimator
 
-**Version:** 1.0.0  
-**Author:** Danyal S.  
-**Blender Support:** 4.2+
+**Version:** 1.4.1
+**Author:** Danyal S.
+**Blender Support:** 4.2 LTS through 5.0
 
----
 
 ## Overview
-**True RoboAnimator** is a Blender add-on that generates **engineering-accurate animations for differential-drive robots**.  
-It provides full motion validation, curvature-safe path smoothing, speed-profile control, and automatic wheel-rotation drivers.  
-Designed for robotics engineers and animators who need physically consistent, non-slip motion for simulation or presentation.
+True RoboAnimator is a Blender add-on that generates engineering-accurate animations for wheeled robots. It supports differential-drive, differential + caster, and skid-steer platforms with 2, 3, 4, or 6 wheels, and provides motion validation, curvature-safe path smoothing, speed-profile control, and automatic wheel-rotation drivers. It is aimed at robotics engineers and technical animators who need physically consistent, non-slip motion for simulation or presentation.
 
----
+
+## Supported Wheel Configurations
+Pick the layout that matches your robot; the panel then shows exactly the wheel slots you need.
+
+| Config | Wheels                       | Kinematics                                                     |
+|--------|------------------------------|----------------------------------------------------------------|
+| 2      | Left 01, Right 01            | Standard differential drive.                                   |
+| 3      | Left 01, Right 01, Caster    | Differential drive + a passive caster that rolls off chassis center forward motion only. |
+| 4      | Left 01/02, Right 01/02      | Skid-steer. Both left wheels share one angle; both right wheels share one angle. |
+| 6      | Left 01/02/03, Right 01/02/03| Rocker / rover skid-steer, same per-side sharing as the 4-wheel case. |
+
+Per-side wheel angles follow the classic differential-drive integration:
+
+    dsL = dx - 0.5 * track_width * dpsi
+    dsR = dx + 0.5 * track_width * dpsi
+    dth = (ds / wheel_radius) * side_sign
+
+The caster (3-wheel only) uses `ds_caster = dx`, independent of yaw, because a real caster pivots freely and its wheel spin tracks forward travel of the chassis center.
+
 
 ## Key Features
-- **Nonholonomic Path Validation** — checks chassis motion for sideways slip violations.  
-- **Autocorrect Modes:**
-  - *S-Ease (Smooth Curve)* — builds Bezier segments with curvature clamps.
-  - *Linear (Rotate–Move–Rotate)* — rotates to face target, drives straight, rotates to final heading.
-- **Speed Profiles:**
-  - *Constant (Trapezoid)* — uniform speed with configurable acceleration/deceleration ramps.
-  - *Global Ease* — smooth start/end for the entire timeline.
-  - *Per-Key Ease* — segment-level easing between keyframes.
-- **Wheel Kinematics Cache** — computes RPM, angular acceleration, and rotation angles per frame.
-- **Automatic Wheel Drivers** — attach rotation drivers to wheel meshes or empties.
-- **CSV Import/Export:**
-  - Export robot trajectories with time, pose, and wheel motion.
-  - Import external CSV animation data into Blender.
-- **Safety Limits:** user-definable wheel speed (RPM) and angular acceleration (RPM/s) caps.
+- **Nonholonomic path validation.** Checks chassis motion for sideways slip violations against a configurable tolerance.
+- **Autocorrect modes.**
+  - *S-Ease (Smooth Curve)*: Bezier segments with a curvature clamp derived from the track width.
+  - *Linear (Rotate, Move, Rotate)*: rotates in place to face the target, drives straight, then rotates to the final heading.
+- **Speed profiles.**
+  - *Constant (Trapezoid)*: uniform cruise speed with configurable linear accel/decel ramp frames.
+  - *Global Ease*: smooth start and end applied across the whole timeline.
+  - *Per-Key Ease*: symmetric ease-in/out inside each keyframe-to-keyframe segment.
+- **Per-configuration wheel kinematics.** Cache holds thetaL, thetaR (and thetaC on 3-wheel) per frame, plus RPM and angular acceleration diagnostics.
+- **Automatic wheel drivers.** Attach rotation drivers to every configured wheel, in Euler or Quaternion mode, with each wheel's own rest orientation.
+- **CSV import and export.**
+  - Export trajectories with time, pose, wheel angles, and wheel rates. thetaC / rateC columns are added when the 3-wheel config is active.
+  - Import external CSV animation data back into Blender using scene FPS and start frame.
+- **Safety limits.** User-definable caps on driven-wheel speed (RPM) and angular acceleration (RPM/s). The caster is diagnostic only.
 
----
 
 ## Installation
-1. Download the repository or `.zip` of the add-on.  
-2. In Blender:  
-   - `Edit` → `Preferences` → `Add-ons` → `Install`.  
-   - Select the downloaded `.zip`.  
-3. Enable **True RoboAnimator** in the Add-on list.  
-4. Access it from the **3D Viewport → N-Panel → True RoboAnimator** tab.
+1. Download the latest `.zip` release, or clone this repository and zip the contents.
+2. In Blender go to *Edit > Preferences > Get Extensions > Install from Disk* (Blender 4.2+).
+3. Select the zip and enable **True RoboAnimator** in the list.
+4. Open the sidebar in the 3D Viewport (`N`) and switch to the **True RoboAnimator** tab.
 
----
+Because drivers run Python expressions, first-time users on a fresh scene should ensure *Auto Run Python Scripts* is enabled (or trust the file) so the wheel drivers evaluate correctly.
+
+
+## Panel Layout
+The N-panel is organized into numbered stages so the workflow reads top to bottom:
+
+1. **Rig Setup.** Assign the chassis, pick a wheel count (2 / 3 / 4 / 6), then fill in the visible wheel slots.
+2. **Calibration.** Track width, tire spacing, wheel radius, wheel rotation axis and mode, per-side rolling direction.
+3. **Motion Path.** Body forward axis, sideways slip tolerance, autocorrect mode, speed profile, and Validate / Autocorrect / Revert actions.
+4. **Wheel Drivers.** Safety limits, then Build Cache, Attach Drivers, Bake Wheels, and Clear.
+5. **Import CSV.** Load a chassis + wheel trajectory back from CSV using scene FPS and start frame.
+6. **Export Keyframes.** Keyframe-only CSV/JSON snapshot at existing chassis keys.
+7. **Engineering CSV.** Time-series CSV at scene rate or a fixed Hz, in your preferred units.
+
 
 ## Basic Workflow
-1. **Assign Objects**
-   - Set your chassis object and left/right wheel collections.
-   - Adjust track width and wheel radius (or enable Auto-detect).
+1. **Rig up.** Set the chassis object and wheel count. Assign each visible wheel slot.
+2. **Calibrate.** Set track width and either enable Auto-detect for the wheel radius or type it in. Pick the wheel rotation axis and mode.
+3. **Animate the chassis.** Keyframe location and rotation on the frames that define the path.
+4. **Validate.** Run *Validate Motion* to confirm no sideways slip.
+5. **Autocorrect if needed.** Pick a mode and speed profile, then *Autocorrect & Bake*. Re-run *Validate Motion*.
+6. **Build cache.** Integrates per-frame wheel angles for every configured wheel and stores them in Blender's driver namespace.
+7. **Attach drivers or bake wheels.** Drivers for live playback, bake for exporting per-frame keyframes to other tools.
+8. **Export.** Engineering CSV or keyframe snapshot for downstream analysis or hardware playback.
 
-2. **Animate Chassis**
-   - Keyframe chassis motion (position + rotation).  
-   - Use *Autocorrect & Bake* to generate feasible differential motion.
-
-3. **Validate**
-   - Run *Validate Motion* to confirm no sideways slip or limit violations.
-
-4. **Build Cache**
-   - Generates wheel angular motion data and stores it in Blender’s driver namespace.
-
-5. **Attach Drivers**
-   - Automatically applies rotation drivers to wheel meshes.
-
-6. **Export Data (optional)**
-   - Export to CSV for further analysis or robot playback.
-
----
 
 ## Requirements
-- **Blender 4.2.0 or newer**  
-- Python 3.11+ (bundled with Blender)  
-- No external dependencies required.
+- Blender 4.2 LTS or newer (tested through Blender 5.0).
+- Python 3.11+ (bundled with Blender).
+- No external Python dependencies.
 
----
 
 ## Known Limitations
-- Designed for **differential-drive** robots only.  
-- Requires valid keyframes on chassis before baking.  
-- Scene FPS affects motion integration accuracy.
+- Skid-steer 4/6-wheel configs assume both wheels on a side share the same angle. Independently steered wheels are not modelled.
+- Requires at least two keyed poses on the chassis (location + rotation) before autocorrect and cache steps.
+- Scene FPS affects motion-integration accuracy. Set the target FPS before building the cache.
 
----
+
+## What's New in 1.4.1
+- **Engineering CSV now exports PHYSICAL thetas and rates.** Positive theta / positive rate means the wheel rolls forward, independent of how the wheel model is oriented. The cache still stores visual (local-axis) thetas for Blender drivers; the exporter multiplies by each wheel's stored sign to convert. Previously an L/R rig with opposite axle orientations produced CSV values that looked "swapped" between left and right.
+- **Tangent Scale no longer plateaus.** Removed the `5 * rho` cap (max L = 2.5 * track_width) and the iterative curvature-shrink loop from the S-Ease segment builder. Tangent Scale now controls curve handle length directly, capped only at 0.49 * chord distance to keep the curve from folding back.
+- **Independent start / end tangents.** The `Tangent Scale` slider is split into `Tangent Scale Start` (P1 handle) and `Tangent Scale End` (P2 handle) so each segment can be shaped asymmetrically. Both default to 0.35.
+
+## What's New in 1.4.0
+- **Wheel rotation direction fix.** The auto-sign math cross-producted the wheel axis with `down` instead of `up`, so every wheel was rolling backwards. Now derived correctly from the rolling-without-slip constraint and verified on paper.
+- **Track width auto-detect.** Track width is now measured as the world distance between `Left Wheel 01` and `Right Wheel 01` by default. The old `Distance Between Tires` field was unused metadata; removed.
+- **`Invert Wheel Rotation` toggle removed.** With the sign math fixed there's no reason to expose it.
+- **`Wheel Rotation Axis` auto-set.** Whenever you change Body Forward Axis the wheel axis snaps to the perpendicular horizontal axis. Still overridable.
+- **Assigning an object auto-applies scale and rotation.** When you pick a chassis or wheel in the panel, its rotation and scale are baked into the mesh (skipped for parented, shared-mesh, already-animated, or already-identity objects), so `matrix_world`, `dimensions`, and the visualization all reflect the true rig geometry.
+- **Panel reorganized.** Viewport Helpers now sits right under Instructions. Import CSV, Export Keyframes, and Engineering CSV collapse into one `Import / Export` section with a mode-tab enum.
+
+## What's New in 1.3.2
+- The solution-path overlay is now a **live preview**. Switching between S-Ease and Linear, sliding Tangent Scale, or changing Rotation Fraction updates the cyan path instantly in the viewport, without needing to Autocorrect & Bake first. It samples S-Ease Bezier geometry directly and treats Linear as a polyline through the waypoints, so what you see is exactly what a bake would produce spatially.
+- N-panel cleanup: dropped section numbering (Motion Path, Wheel Drivers, etc), removed most nested sub-boxes, trimmed labels, and cut the color legend. Same content, less visual noise.
+
+## What's New in 1.3.1
+- Wheel rotation direction is now auto-detected per wheel from the wheel's world-space rotation axis and the body forward vector, so `Left/Right/Caster Wheel Direction` and the `Invert Wheel Forward` toggle are gone. If all wheels roll the wrong way, use the single `Invert Wheel Rotation` fallback.
+- Raw / solution path overlays now work on Blender 4.4+ slotted actions: the action-fcurve compat layer walks `layers -> strips -> channelbags` so location fcurves are found regardless of storage.
+- Wheel-axis gizmo shortened. Length now scales to about 2 x tire width (using the smallest bbox dimension of the wheel as the tire-width proxy) instead of the previous over-long line.
+
+## What's New in 1.3.0
+- New Viewport Helpers overlay drawn as construction lines in every 3D View, updated live as settings change:
+  - Green forward-axis arrow on the chassis for the selected Body Forward Axis.
+  - Colored rotation-axis line through every configured wheel (red for left, blue for right, yellow for the caster) with a small tick at the positive-theta end.
+  - Orange raw path with waypoint dots at every chassis keyframe (falls back to the autocorrect backup when present, so you see the original intent after baking).
+  - Cyan solution path that samples the current chassis animation at every frame.
+- Per-toggle checkboxes plus a master toggle in a new Viewport Helpers section of the panel.
+- Overlay always draws through geometry so it stays visible during modeling.
+
+## What's New in 1.2.0
+- New wheel selection UI. Individual wheel Object slots (Left Wheel 01, Right Wheel 02, ...) replace the old Left/Right collection pickers.
+- New Wheel Configuration selector: 2, 3, 4, or 6 wheels. The panel shows exactly the slots that config needs.
+- Caster wheel support for the 3-wheel config, with its own rest orientation, driver expression, and CSV column.
+- Skid-steer 4 and 6-wheel configs replicate the per-side angle to every wheel on that side.
+- Panel rewrite: numbered stages, consistent sub-boxes, and icons on every action.
+
+## What's New in 1.1.0
+- Blender 5.0 support. Added a compatibility layer for slotted actions introduced in Blender 4.4 so action creation, fcurve reads, and fcurve writes are safe across 4.2, 4.3, 4.4, and 5.0.
+- Fixed missing top-level imports that previously prevented the module from loading in some Blender builds.
+- CSV import now uses the scene's FPS and start frame instead of a hard-coded 30 FPS / frame-1 origin.
+- Fixed `Invert Wheel Forward`: previously the sign flip and an extra `dx = -dx` cancelled each other for translation while inverting only yaw. The flag now consistently inverts every wheel's rotation.
+- Fixed cumulative drift in the CSV quaternion importer: rest orientation is captured once per wheel instead of being re-read after each keyframe write.
+- Fixed `Bake Wheels` in quaternion mode: each wheel is now baked against its own rest orientation rather than the first wheel's rest.
+- Consistent ASCII text in UI labels and README for scripting-friendly output.
+
 
 ## License
-**GNU General Public License v3.0 (GPL-3.0)**  
-This add-on follows Blender’s licensing requirements.  
-You are free to use, modify, and redistribute it under the same license.
+GNU General Public License v3.0 (GPL-3.0). This add-on follows Blender's licensing requirements. You are free to use, modify, and redistribute it under the same license.
 
----
 
 ## Citation
 If used in academic work, please cite as:
 
-> Sarfraz, D. (2025). *True RoboAnimator: Engineering-Accurate Differential-Drive Animation Toolkit for Blender 4.2*.  
+> Sarfraz, D. (2025). *True RoboAnimator: Engineering-Accurate Wheeled-Robot Animation Toolkit for Blender*.
 > Graduate Thesis Project, Ulsan National Institute of Science and Technology (UNIST).
 
----
 
 ## Contact
 For issues or feature requests, open a GitHub issue or contact the author.
-- [LinkedIn — Danyal Sarfraz](https://www.linkedin.com/in/danyal-sarfraz)
-
+- LinkedIn: [Danyal Sarfraz](https://www.linkedin.com/in/danyal-sarfraz)

--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,147 @@
 bl_info = {
     "name": "True RoboAnimator",
     "author": "Danyal S.",
-    "version": (1, 0, 0),
+    "version": (1, 4, 1),
     "blender": (4, 2, 0),
     "location": "3D Viewport > N-Panel > True RoboAnimator",
-    "description": "Engineering-accurate animation toolkit for differential-drive robots.",
+    "description": "Engineering-accurate animation toolkit for differential-drive and skid-steer robots.",
     "category": "Animation",
 }
+
+import bpy
+import os
+import json
+import bisect
+from math import pi, sin, cos, atan2, sqrt, floor
+from mathutils import Vector
+
+
+# ---------------------- Blender 4.4+ slotted-action compatibility ----------------------
+def _bl_version():
+    return bpy.app.version  # e.g. (5, 0, 0)
+
+
+def _ensure_action_for(obj, action_name="Action"):
+    """
+    Ensure obj has animation_data + an assigned Action.
+    On Blender 4.4+ a fresh action needs a slot bound to the object before
+    fcurves.new() / keyframe_insert() will actually store data.
+    Returns the assigned Action.
+    """
+    if obj.animation_data is None:
+        obj.animation_data_create()
+    ad = obj.animation_data
+    if ad.action is None:
+        ad.action = bpy.data.actions.new(name=action_name)
+    act = ad.action
+
+    # Slotted-action API (Blender 4.4+): make sure a slot is assigned.
+    if hasattr(act, "slots"):
+        try:
+            slot = getattr(ad, "action_slot", None)
+            if slot is None:
+                if len(act.slots) == 0:
+                    slot = act.slots.new(id_type='OBJECT', name=obj.name)
+                else:
+                    slot = act.slots[0]
+                try:
+                    ad.action_slot = slot
+                except Exception:
+                    pass
+        except Exception:
+            pass
+    return act
+
+
+def _iter_action_fcurves(action):
+    """
+    Iterate fcurves of an action across legacy and slotted representations.
+    In Blender 4.4+ a slotted action can store its fcurves inside
+    layers[i].strips[j].channelbags[k] instead of the top-level
+    action.fcurves collection, so we walk both.
+    """
+    if action is None:
+        return
+    seen = set()
+
+    fcs = getattr(action, "fcurves", None)
+    if fcs is not None:
+        for fc in fcs:
+            key = (fc.data_path, fc.array_index)
+            if key not in seen:
+                seen.add(key)
+                yield fc
+
+    layers = getattr(action, "layers", None)
+    if not layers:
+        return
+    for layer in layers:
+        strips = getattr(layer, "strips", None) or []
+        for strip in strips:
+            cbgs = getattr(strip, "channelbags", None) or []
+            for cbg in cbgs:
+                cb_fcs = getattr(cbg, "fcurves", None)
+                if not cb_fcs:
+                    continue
+                for fc in cb_fcs:
+                    key = (fc.data_path, fc.array_index)
+                    if key not in seen:
+                        seen.add(key)
+                        yield fc
+
+
+def _find_channelbag_of(action, fc):
+    layers = getattr(action, "layers", None) or []
+    for layer in layers:
+        strips = getattr(layer, "strips", None) or []
+        for strip in strips:
+            for cbg in getattr(strip, "channelbags", None) or []:
+                for f in getattr(cbg, "fcurves", None) or []:
+                    if f == fc:
+                        return cbg
+    return None
+
+
+def _remove_action_fcurve(action, fc):
+    # Try the legacy container first.
+    fcs = getattr(action, "fcurves", None)
+    if fcs is not None:
+        try:
+            fcs.remove(fc); return
+        except Exception:
+            pass
+    # Fall back to slot channelbags.
+    cbg = _find_channelbag_of(action, fc)
+    if cbg is not None:
+        try:
+            cbg.fcurves.remove(fc)
+        except Exception:
+            pass
+
+
+def _new_action_fcurve(action, data_path, index):
+    # Reuse an existing fcurve if the compat iterator can find one.
+    for fc in _iter_action_fcurves(action):
+        if fc.data_path == data_path and fc.array_index == index:
+            return fc
+
+    fcs = getattr(action, "fcurves", None)
+    if fcs is not None:
+        try:
+            return fcs.new(data_path=data_path, index=index)
+        except Exception:
+            pass
+
+    layers = getattr(action, "layers", None)
+    if layers:
+        for layer in layers:
+            for strip in getattr(layer, "strips", None) or []:
+                for cbg in getattr(strip, "channelbags", None) or []:
+                    try:
+                        return cbg.fcurves.new(data_path=data_path, index=index)
+                    except Exception:
+                        continue
+    return None
 
 
 # ---------------------- constants & keys ----------------------
@@ -150,56 +285,121 @@ def _lerp(a,b,t): return a*(1.0-t)+b*t
 
 # ---------------------- backup / restore chassis keys ----------------------
 def _collect_fcurves(obj):
-    ad=obj.animation_data
-    if not (ad and ad.action): return []
-    return [fc for fc in ad.action.fcurves if fc.data_path in ("location","rotation_euler")]
+    ad = obj.animation_data
+    if not (ad and ad.action):
+        return []
+    return [fc for fc in _iter_action_fcurves(ad.action)
+            if fc.data_path in ("location", "rotation_euler")]
 
 def _backup_chassis_keys(ch):
-    data={}
+    data = {}
     for fc in _collect_fcurves(ch):
-        key=f"{fc.data_path}[{fc.array_index}]"
-        data[key]=[[float(kp.co[0]), float(kp.co[1])] for kp in fc.keyframe_points]
-    key=f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
-    txt=bpy.data.texts.get(key) or bpy.data.texts.new(key)
-    txt.clear(); txt.write(json.dumps(data))
+        key = f"{fc.data_path}[{fc.array_index}]"
+        data[key] = [[float(kp.co[0]), float(kp.co[1])] for kp in fc.keyframe_points]
+    key = f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
+    txt = bpy.data.texts.get(key) or bpy.data.texts.new(key)
+    txt.clear()
+    txt.write(json.dumps(data))
     return True
 
 def _restore_chassis_keys(ch):
-    key=f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
-    txt=bpy.data.texts.get(key)
-    if not txt or len(txt.as_string())==0: return False
-    try: data=json.loads(txt.as_string())
-    except Exception: return False
-    if not ch.animation_data: ch.animation_data_create()
-    if not ch.animation_data.action:
-        ch.animation_data.action=bpy.data.actions.new(name="ChassisAction")
-    ad=ch.animation_data
-    if ad and ad.action:
-        for fc in list(ad.action.fcurves):
-            if fc.data_path in ("location","rotation_euler"):
-                try: ad.action.fcurves.remove(fc)
-                except Exception: pass
+    key = f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
+    txt = bpy.data.texts.get(key)
+    if not txt or len(txt.as_string()) == 0:
+        return False
+    try:
+        data = json.loads(txt.as_string())
+    except Exception:
+        return False
+
+    act = _ensure_action_for(ch, action_name="ChassisAction")
+    for fc in list(_iter_action_fcurves(act)):
+        if fc.data_path in ("location", "rotation_euler"):
+            _remove_action_fcurve(act, fc)
+
     _ensure_xyz_euler(ch)
-    for key,rows in data.items():
+    for key, rows in data.items():
         if key.startswith("location["):
-            path="location"; idx=int(key.split("[")[1][0])
+            path = "location"; idx = int(key.split("[")[1][0])
         elif key.startswith("rotation_euler["):
-            path="rotation_euler"; idx=int(key.split("[")[1][0])
-        else: continue
-        fc=ch.animation_data.action.fcurves.new(data_path=path,index=idx)
-        for fr,val in rows:
+            path = "rotation_euler"; idx = int(key.split("[")[1][0])
+        else:
+            continue
+        fc = _new_action_fcurve(act, path, idx)
+        if fc is None:
+            continue
+        for fr, val in rows:
             fc.keyframe_points.insert(frame=fr, value=val, options={'FAST'})
-    txt.clear(); return True
+    txt.clear()
+    return True
 
 # ---------------------- side helpers ----------------------
-def _col_for_side(P, side):
-    return (P.left_collection if side=='L' else P.right_collection) if not P.swap_lr else \
-           (P.right_collection if side=='L' else P.left_collection)
+def _wheel_count(P):
+    try:
+        return int(P.num_wheels)
+    except Exception:
+        return 2
+
+
+def _effective_track_width(P):
+    """
+    Return the track width used by every calculation.
+    If auto_track_width is on and both wheel_l_01 and wheel_r_01 are set,
+    it is the world distance between their origins. Otherwise the manual
+    track_width value is used.
+    """
+    if getattr(P, "auto_track_width", True):
+        wL = getattr(P, "wheel_l_01", None)
+        wR = getattr(P, "wheel_r_01", None)
+        if wL and wR:
+            d = (wL.matrix_world.translation - wR.matrix_world.translation).length
+            if d > 1e-5:
+                return d
+    return max(float(getattr(P, "track_width", 0.25)), 1e-5)
+
+
+def _wheel_slots_for(P, side):
+    """
+    Return the ORDERED list of wheel-slot pointers for the given side
+    ('L' or 'R'), respecting num_wheels and swap_lr.
+    Empty slots and missing objects are filtered out later by _iter_side.
+    """
+    n = _wheel_count(P)
+    if n == 2:
+        left, right = [P.wheel_l_01], [P.wheel_r_01]
+    elif n == 3:
+        left, right = [P.wheel_l_01], [P.wheel_r_01]
+    elif n == 4:
+        left, right = [P.wheel_l_01, P.wheel_l_02], [P.wheel_r_01, P.wheel_r_02]
+    elif n == 6:
+        left  = [P.wheel_l_01, P.wheel_l_02, P.wheel_l_03]
+        right = [P.wheel_r_01, P.wheel_r_02, P.wheel_r_03]
+    else:
+        left, right = [P.wheel_l_01], [P.wheel_r_01]
+
+    if P.swap_lr:
+        left, right = right, left
+    return left if side == 'L' else right
+
 
 def _iter_side(P, side):
-    col=_col_for_side(P,side)
-    if not col: return []
-    return [o for o in col.objects if o.type in {'MESH','EMPTY'}]
+    """Return the resolved list of wheel Objects on the given side."""
+    if side == 'C':
+        c = P.wheel_caster
+        return [c] if (c and c.type in {'MESH', 'EMPTY'}) else []
+    return [o for o in _wheel_slots_for(P, side)
+            if o is not None and o.type in {'MESH', 'EMPTY'}]
+
+
+def _iter_all_wheels(P):
+    """L wheels + R wheels + caster (if configured), deduplicated."""
+    seen, out = set(), []
+    for side in ('L', 'R', 'C'):
+        for o in _iter_side(P, side):
+            k = id(o)
+            if k not in seen:
+                seen.add(k); out.append(o)
+    return out
 
 # ---------------------- body basis from heading + forward-axis ----------------------
 def _body_basis_from_yaw(theta, forward_axis):
@@ -215,7 +415,8 @@ def _body_basis_from_yaw(theta, forward_axis):
 def analyze_motion(context):
     P=context.scene.sg_props; ch=P.chassis
     if not ch: raise RuntimeError("Assign the Chassis.")
-    if P.track_width<=0: raise RuntimeError("Track width must be > 0.")
+    track = _effective_track_width(P)
+    if track <= 0: raise RuntimeError("Track width must be > 0.")
     scn=context.scene; deps=context.evaluated_depsgraph_get()
     if scn.frame_end<=scn.frame_start: raise RuntimeError("Scene frame range invalid.")
 
@@ -238,14 +439,14 @@ def analyze_motion(context):
         dy=dp_x*lat[0] + dp_y*lat[1]
         if abs(dy) > (P.side_tol*dt): violations+=1; v_frames.append(f)
         prev_loc=loc.copy(); prev_yaw=yaw
-    return {'f0':f0,'fps':fps,'track':P.track_width,'violations':violations,'violation_frames':v_frames,'side_tol':P.side_tol,'dt':dt}
+    return {'f0':f0,'fps':fps,'track':track,'violations':violations,'violation_frames':v_frames,'side_tol':P.side_tol,'dt':dt}
 
 # ---------------------- gather keyed poses ----------------------
 def _get_chassis_key_poses(P,ch):
     frames=set()
     ad=ch.animation_data
     if ad and ad.action:
-        for fc in ad.action.fcurves:
+        for fc in _iter_action_fcurves(ad.action):
             if fc.data_path in ("location","rotation_euler"):
                 for kp in fc.keyframe_points:
                     frames.add(int(round(kp.co[0])))
@@ -261,55 +462,53 @@ def _get_chassis_key_poses(P,ch):
     return out
 
 # ---------------------- bake helper ----------------------
-def _bake_chassis_frames_from_heading_samples(P,ch,samples):
+def _bake_chassis_frames_from_heading_samples(P, ch, samples):
     _ensure_xyz_euler(ch)
-    scn=bpy.context.scene; deps=bpy.context.evaluated_depsgraph_get()
-    ad=ch.animation_data
-    if ad and ad.action:
-        for fc in list(ad.action.fcurves):
-            if fc.data_path in ("location","rotation_euler"):
-                try: ad.action.fcurves.remove(fc)
-                except Exception: pass
-    for f,x,y,z,h in samples:
-        ch.location.x=x; ch.location.y=y; ch.location.z=z
-        ch.rotation_euler[0]=0.0; ch.rotation_euler[1]=0.0
-        ch.rotation_euler[2]=heading_to_yaw(P,h)
+    scn = bpy.context.scene
+    deps = bpy.context.evaluated_depsgraph_get()
+    act = _ensure_action_for(ch, action_name="ChassisAction")
+    for fc in list(_iter_action_fcurves(act)):
+        if fc.data_path in ("location", "rotation_euler"):
+            _remove_action_fcurve(act, fc)
+    for f, x, y, z, h in samples:
+        ch.location.x = x; ch.location.y = y; ch.location.z = z
+        ch.rotation_euler[0] = 0.0; ch.rotation_euler[1] = 0.0
+        ch.rotation_euler[2] = heading_to_yaw(P, h)
         ch.keyframe_insert("location", frame=f, index=-1)
         ch.keyframe_insert("rotation_euler", frame=f, index=-1)
-    deps.update(); scn.frame_set(scn.frame_start); deps.update()
+    deps.update()
+    scn.frame_set(scn.frame_start)
+    deps.update()
 
 # ---------------------- S-curve build + bake ----------------------
-def _build_s_ease_curve_segment(poseA, poseB, rho, tangent_scale):
-    (x0,y0,h0) = poseA
-    (x3,y3,h3) = poseB
+def _build_s_ease_curve_segment(poseA, poseB, tangent_start, tangent_end):
+    """
+    Cubic Bezier between two chassis waypoints. The start handle (P1)
+    length is tangent_start * chord_distance, the end handle (P2) length
+    is tangent_end * chord_distance. Both handles are clamped to at most
+    0.49 * chord_distance so the curve never loops back on itself.
+    """
+    (x0, y0, h0) = poseA
+    (x3, y3, h3) = poseB
 
     chord = atan2(y3 - y0, x3 - x0)
     def _align(h, ref):
         a = _wrap(h - ref)
-        return h if abs(a) <= pi/2 else _wrap(h + pi)
+        return h if abs(a) <= pi / 2 else _wrap(h + pi)
     h0 = _align(h0, chord)
     h3 = _align(h3, chord)
 
-    P0=(x0,y0); P3=(x3,y3)
-    dx=x3-x0; dy=y3-y0; dist=max(1e-6, sqrt(dx*dx+dy*dy))
+    P0 = (x0, y0); P3 = (x3, y3)
+    dx = x3 - x0; dy = y3 - y0
+    dist = max(1e-6, sqrt(dx * dx + dy * dy))
+    cap = 0.49 * dist
 
-    L=min(dist*tangent_scale, 5.0*rho, 0.49*dist)
-    if L<1e-8: L=1e-8
+    L_start = max(min(dist * tangent_start, cap), 1e-8)
+    L_end   = max(min(dist * tangent_end,   cap), 1e-8)
 
-    P1=(x0 + L*cos(h0), y0 + L*sin(h0))
-    P2=(x3 - L*cos(h3), y3 - L*sin(h3))
-
-    max_k_allow=(1.0/rho)*1.02
-    for _ in range(12):
-        exceeds=False
-        for t in (0.15,0.35,0.5,0.65,0.85):
-            _,_,_,k=_bezier_eval(P0,P1,P2,P3,t)
-            if k>max_k_allow: exceeds=True; break
-        if not exceeds: break
-        L*=0.8; L=max(min(L,0.49*dist),1e-8)
-        P1=(x0 + L*cos(h0), y0 + L*sin(h0))
-        P2=(x3 - L*cos(h3), y3 - L*sin(h3))
-    return P0,P1,P2,P3
+    P1 = (x0 + L_start * cos(h0), y0 + L_start * sin(h0))
+    P2 = (x3 - L_end   * cos(h3), y3 - L_end   * sin(h3))
+    return P0, P1, P2, P3
 
 def build_s_ease_curve_and_bake(context):
     P=context.scene.sg_props; ch=P.chassis
@@ -318,8 +517,8 @@ def build_s_ease_curve_and_bake(context):
     if not (ch.animation_data and ch.animation_data.action):
         raise RuntimeError("Chassis has no animation to autocorrect.")
 
-    rho=max(P.track_width*0.5, 1e-5)
-    tangent_scale=P.bezier_tangent_scale
+    tangent_start = P.bezier_tangent_start
+    tangent_end   = P.bezier_tangent_end
 
     profile=getattr(P,"speed_profile",'CONSTANT')
     f0,f1=scn.frame_start, scn.frame_end
@@ -343,13 +542,12 @@ def build_s_ease_curve_and_bake(context):
         fA,xA,yA,zA,_yA,hA=poses[i]
         fB,xB,yB,zB,_yB,hB=poses[i+1]
         spans.append(max(1, fB-fA))
-        P0,P1,P2,P3=_build_s_ease_curve_segment((xA,yA,hA),(xB,yB,hB), rho, tangent_scale)
+        P0,P1,P2,P3=_build_s_ease_curve_segment((xA,yA,hA),(xB,yB,hB), tangent_start, tangent_end)
         lut_norm,L=_build_arc_lut_norm_total_xy(P0,P1,P2,P3,steps=128)
         if L<=1e-12: continue
         segs.append({"P0":P0,"P1":P1,"P2":P2,"P3":P3,"zA":zA,"zB":zB,"L":L,"lut":lut_norm})
         total_len+=L
 
-    import bisect
     baked=[]; last_h=0.0
     cum_frames=[]; cum_len=[]; acc_f=0.0; acc_L=0.0
     for i,seg in enumerate(segs):
@@ -453,7 +651,6 @@ def build_linear_path_and_bake(context):
             })
             total_len+=L
 
-    import bisect
     cum_len=[]; acc_L=0.0
     for s in segs:
         if s.get("L",0.0)>0.0:
@@ -603,7 +800,13 @@ def build_linear_path_and_bake(context):
 
 # ---------------------- Edge ease tools (used by other profiles) ----------------------
 def _edge_ease_progress(tau, ease_frac):
-    """Symmetric edge ease on [0,1], continuous at the joins (C1)."""
+    """
+    Symmetric edge ease on [0,1] with linear-ramp accel and decel.
+    Position is C0 continuous at the joins tau=f and tau=1-f. Velocity has
+    a small step at each join because the cruise velocity (1-f)/(1-2f) is
+    higher than the ramp end velocity 1.0; for a C1 profile use
+    _trapezoid_s instead.
+    """
     f=max(0.0, min(0.49, ease_frac))
     if f<=1e-12: return tau
     if tau<=f: return (tau*tau)/(2.0*f)              # linear accel
@@ -623,6 +826,34 @@ def _edge_ease_progress_asym(u, fin, fout):
     return 0.5*fin + (u-mid0)*(1.0-0.5*fin-0.5*fout)/max(1e-12,m)
 
 # ---------------------- cache build for wheel drivers ----------------------
+def _wheel_sign_auto(wheel_obj, wheel_axis_char, body_fwd_world):
+    """
+    Return +1 or -1 so that a positive theta rolls the vehicle forward.
+
+    Derivation (rolling-without-slip constraint):
+      Chassis moves forward at V along body_fwd. The wheel's ground-contact
+      point at position r = -R*z_hat has velocity (in the wheel-center
+      frame) v = omega x r = -R*omega*(A x z_hat), where A is the wheel's
+      local rotation axis in world space. For no slip the contact point is
+      stationary in the world frame, so v = -V * body_fwd.
+      Solving: omega_scalar = V / (R * (A x z_hat) . body_fwd).
+      Therefore sign(theta) = sign((A x up) . body_fwd) for V > 0.
+    """
+    if not wheel_obj:
+        return 1.0
+    m3 = wheel_obj.matrix_world.to_3x3()
+    world_axis = m3 @ Vector(_axis_unit(wheel_axis_char))
+    if world_axis.length < 1e-9:
+        return 1.0
+    world_axis.normalize()
+    up = Vector((0.0, 0.0, 1.0))
+    tangent = world_axis.cross(up)
+    if tangent.length < 1e-9:
+        return 1.0
+    tangent.normalize()
+    return 1.0 if tangent.dot(body_fwd_world) > 0.0 else -1.0
+
+
 def _obj_rest_quat(obj):
     if not obj: return (1.0,0.0,0.0,0.0)
     if getattr(obj,'rotation_mode','XYZ')=='QUATERNION':
@@ -645,116 +876,169 @@ def build_cache(context):
         raise RuntimeError(f"Infeasible motion: {a['violations']} frame(s) exceed sideways tolerance > {a['side_tol']} "
                            f"(e.g., frames {a['violation_frames'][:10]}).")
 
-    colL=_col_for_side(P,'L'); colR=_col_for_side(P,'R')
-    wL0=colL.objects[0] if (colL and len(colL.objects)>0) else None
-    wR0=colR.objects[0] if (colR and len(colR.objects)>0) else None
-    restL=_obj_rest_quat(wL0); restR=_obj_rest_quat(wR0)
+    wL_list = _iter_side(P, 'L')
+    wR_list = _iter_side(P, 'R')
+    wC = P.wheel_caster if _wheel_count(P) == 3 else None
+    wL0 = wL_list[0] if wL_list else None
+    wR0 = wR_list[0] if wR_list else None
+    if wL0 is None or wR0 is None:
+        raise RuntimeError("Assign at least Left Wheel 01 and Right Wheel 01.")
+    restL = _obj_rest_quat(wL0)
+    restR = _obj_rest_quat(wR0)
+    restC = _obj_rest_quat(wC) if wC else (1.0, 0.0, 0.0, 0.0)
 
-    signL=+1.0 if P.sign_l=='PLUS' else -1.0
-    signR=+1.0 if P.sign_r=='PLUS' else -1.0
-    try:
-        if P.wheel_forward_invert:
-            signL*=-1.0; signR*=-1.0
-    except Exception:
-        pass
-    b=P.track_width
+    b = _effective_track_width(P)
     if P.auto_radius:
-        w_ref=wL0 or wR0
-        if not w_ref: raise RuntimeError("Put at least one wheel object into the Right/Left collections.")
-        radius=_auto_radius(w_ref, P.wheel_axis)
+        w_ref = wL0 or wR0 or wC
+        if not w_ref:
+            raise RuntimeError("Assign at least one wheel object to enable auto radius detection.")
+        radius = _auto_radius(w_ref, P.wheel_axis)
     else:
-        radius=P.wheel_radius
-    if radius<=0: raise RuntimeError("Wheel radius must be > 0.")
+        radius = P.wheel_radius
+    if radius <= 0:
+        raise RuntimeError("Wheel radius must be > 0.")
 
-    scn=context.scene; deps=context.evaluated_depsgraph_get()
-    fps=scn.render.fps/scn.render.fps_base
-    dt=1.0/float(fps); f0=scn.frame_start; f1=scn.frame_end
-    thetaL=[0.0]; thetaR=[0.0]; pos_x=[]; pos_y=[]; yaw_z=[]
+    scn = context.scene
+    deps = context.evaluated_depsgraph_get()
+    fps = scn.render.fps / scn.render.fps_base
+    dt = 1.0 / float(fps)
+    f0 = scn.frame_start; f1 = scn.frame_end
 
+    # Sample the chassis at the start frame so we can auto-derive per-wheel
+    # rotation signs from geometry: whichever way the wheel's local rotation
+    # axis actually points in world space, positive theta should mean forward
+    # roll.
     scn.frame_set(f0); deps.update()
-    prev_loc=ch.matrix_world.translation.copy()
-    prev_yaw=ch.matrix_world.to_euler('XYZ').z
+    initial_yaw = ch.matrix_world.to_euler('XYZ').z
+    fwd_2d, _lat = _body_basis_from_yaw(initial_yaw, P.body_forward_axis)
+    body_fwd_world = Vector((fwd_2d[0], fwd_2d[1], 0.0))
+    if body_fwd_world.length < 1e-9:
+        body_fwd_world = Vector((0.0, 1.0, 0.0))
+    body_fwd_world.normalize()
+
+    signL = _wheel_sign_auto(wL0, P.wheel_axis, body_fwd_world)
+    signR = _wheel_sign_auto(wR0, P.wheel_axis, body_fwd_world)
+    signC = _wheel_sign_auto(wC,  P.wheel_axis, body_fwd_world) if wC else 1.0
+
+    thetaL = [0.0]; thetaR = [0.0]; thetaC = [0.0]
+    pos_x = []; pos_y = []; yaw_z = []
+
+    prev_loc = ch.matrix_world.translation.copy()
+    prev_yaw = initial_yaw
     pos_x.append(prev_loc.x); pos_y.append(prev_loc.y); yaw_z.append(prev_yaw)
-    tL=tR=0.0
-    rpmL_list=[0.0]; rpmR_list=[0.0]
+    tL = tR = tC = 0.0
+    rpmL_list = [0.0]; rpmR_list = [0.0]; rpmC_list = [0.0]
 
-    for f in range(f0+1, f1+1):
+    # In diff-drive kinematics the two driven sides share the same formula
+    # regardless of how many wheels are mounted on each side; skid-steer 4/6
+    # configurations just replicate the per-side wheel angle onto extra wheels
+    # downstream. The caster (3-wheel only) rolls off dx alone.
+    for f in range(f0 + 1, f1 + 1):
         scn.frame_set(f); deps.update()
-        loc=ch.matrix_world.translation
-        yaw=_unwrap(prev_yaw, ch.matrix_world.to_euler('XYZ').z)
-        yaw_mid=_wrap((prev_yaw+yaw)*0.5)
+        loc = ch.matrix_world.translation
+        yaw = _unwrap(prev_yaw, ch.matrix_world.to_euler('XYZ').z)
+        yaw_mid = _wrap((prev_yaw + yaw) * 0.5)
 
-        dp_x=loc.x-prev_loc.x; dp_y=loc.y-prev_loc.y
-        fwd,_lat=_body_basis_from_yaw(yaw_mid, P.body_forward_axis)
-        dx=dp_x*fwd[0] + dp_y*fwd[1]
+        dp_x = loc.x - prev_loc.x; dp_y = loc.y - prev_loc.y
+        fwd, _lat = _body_basis_from_yaw(yaw_mid, P.body_forward_axis)
+        dx = dp_x * fwd[0] + dp_y * fwd[1]
 
-        if P.wheel_forward_invert:
-            dx = -dx
+        dpsi = yaw - prev_yaw
+        dsL = dx - 0.5 * b * dpsi
+        dsR = dx + 0.5 * b * dpsi
+        dthL = (dsL / radius) * signL
+        dthR = (dsR / radius) * signR
+        dthC = (dx  / radius) * signC  # caster: forward roll only
 
-        dpsi=yaw - prev_yaw
-        dsL=dx - 0.5*b*dpsi
-        dsR=dx + 0.5*b*dpsi
-        dthL=(dsL/radius)*signL; dthR=(dsR/radius)*signR
-        tL+=dthL; tR+=dthR
-        thetaL.append(tL); thetaR.append(tR)
+        tL += dthL; tR += dthR; tC += dthC
+        thetaL.append(tL); thetaR.append(tR); thetaC.append(tC)
         pos_x.append(loc.x); pos_y.append(loc.y); yaw_z.append(yaw)
 
-        rpmL=(dthL*fps)*60.0/(2.0*pi); rpmR=(dthR*fps)*60.0/(2.0*pi)
-        rpmL_list.append(rpmL); rpmR_list.append(rpmR)
+        rpmL = (dthL * fps) * 60.0 / (2.0 * pi)
+        rpmR = (dthR * fps) * 60.0 / (2.0 * pi)
+        rpmC = (dthC * fps) * 60.0 / (2.0 * pi)
+        rpmL_list.append(rpmL); rpmR_list.append(rpmR); rpmC_list.append(rpmC)
 
-        prev_loc=loc.copy(); prev_yaw=yaw
+        prev_loc = loc.copy(); prev_yaw = yaw
 
-    # limits
-    max_rpm_limit   = float(getattr(P, "max_rpm", 0.0))
-    max_arpm_s_limit= float(getattr(P, "max_ang_accel_rpm_s", 0.0))
+    # Only the driven wheels are checked against the safety limits;
+    # a caster is passive and its RPM is a diagnostic, not a spec.
+    max_rpm_limit    = float(getattr(P, "max_rpm", 0.0))
+    max_arpm_s_limit = float(getattr(P, "max_ang_accel_rpm_s", 0.0))
 
     if max_rpm_limit > 0.0:
-        over=[]
-        for i,(rL,rR) in enumerate(zip(rpmL_list, rpmR_list)):
-            if abs(rL)>max_rpm_limit or abs(rR)>max_rpm_limit:
-                over.append(f0+i)
+        over = []
+        for i, (rL, rR) in enumerate(zip(rpmL_list, rpmR_list)):
+            if abs(rL) > max_rpm_limit or abs(rR) > max_rpm_limit:
+                over.append(f0 + i)
         if over:
-            head=", ".join(map(str, over[:12])) + (" …" if len(over)>12 else "")
+            head = ", ".join(map(str, over[:12])) + (" ..." if len(over) > 12 else "")
             raise RuntimeError(f"Wheel RPM limit exceeded (>{max_rpm_limit:.1f} rpm) at frames: {head}")
 
     if max_arpm_s_limit > 0.0:
-        over=[]
-        for i in range(1,len(rpmL_list)):
-            aL=(rpmL_list[i]-rpmL_list[i-1]) * fps  # rpm per second
-            aR=(rpmR_list[i]-rpmR_list[i-1]) * fps
-            if abs(aL)>max_arpm_s_limit or abs(aR)>max_arpm_s_limit:
-                over.append(f0+i)
+        over = []
+        for i in range(1, len(rpmL_list)):
+            aL = (rpmL_list[i] - rpmL_list[i - 1]) * fps
+            aR = (rpmR_list[i] - rpmR_list[i - 1]) * fps
+            if abs(aL) > max_arpm_s_limit or abs(aR) > max_arpm_s_limit:
+                over.append(f0 + i)
         if over:
-            head=", ".join(map(str, over[:12])) + (" …" if len(over)>12 else "")
+            head = ", ".join(map(str, over[:12])) + (" ..." if len(over) > 12 else "")
             raise RuntimeError(f"Wheel angular-accel limit exceeded (>{max_arpm_s_limit:.1f} rpm/s) at frames: {head}")
 
-    data={'f0':f0,'fps':fps,'thetaL':thetaL,'thetaR':thetaR,'x':pos_x,'y':pos_y,'yaw':yaw_z,
-          'restL':restL,'restR':restR,'radius':radius,'track':b,
-          'max_rpm_L':max(abs(r) for r in rpmL_list),'max_rpm_R':max(abs(r) for r in rpmR_list),
-          'violations':0,'violation_frames':[]}
+    data = {
+        'f0': f0, 'fps': fps,
+        # thetaX arrays are VISUAL rotations about each wheel's local axis
+        # (what Blender drivers apply). To recover the PHYSICAL forward-roll
+        # angle, multiply by the corresponding sign_* below (sign is +/-1).
+        'thetaL': thetaL, 'thetaR': thetaR, 'thetaC': thetaC,
+        'signL': signL, 'signR': signR, 'signC': signC,
+        'x': pos_x, 'y': pos_y, 'yaw': yaw_z,
+        'restL': restL, 'restR': restR, 'restC': restC,
+        'radius': radius, 'track': b,
+        'num_wheels': _wheel_count(P),
+        'max_rpm_L': max(abs(r) for r in rpmL_list),
+        'max_rpm_R': max(abs(r) for r in rpmR_list),
+        'max_rpm_C': max(abs(r) for r in rpmC_list) if rpmC_list else 0.0,
+        'violations': 0, 'violation_frames': [],
+    }
     bpy.app.driver_namespace[_driver_key()] = data
     return data
 
 # ---------------------- driver functions (for expressions) ----------------------
+def _theta_array_for(d, side):
+    if side == 'L': return d.get('thetaL', [0.0])
+    if side == 'R': return d.get('thetaR', [0.0])
+    return d.get('thetaC', [0.0])
+
+def _rest_quat_for(d, side):
+    if side == 'L': return d.get('restL', (1.0, 0.0, 0.0, 0.0))
+    if side == 'R': return d.get('restR', (1.0, 0.0, 0.0, 0.0))
+    return d.get('restC', (1.0, 0.0, 0.0, 0.0))
+
 def sg_theta(side, frame):
-    d=bpy.app.driver_namespace.get(_driver_key())
+    d = bpy.app.driver_namespace.get(_driver_key())
     if not d: return 0.0
-    i=int(frame - d['f0']); i=max(0, min(i, len(d['thetaL'])-1))
-    return d['thetaL'][i] if side=='L' else d['thetaR'][i]
+    arr = _theta_array_for(d, side)
+    i = int(frame - d['f0'])
+    i = max(0, min(i, len(arr) - 1))
+    return arr[i]
 
 def sg_quat_comp(side, frame, comp_index, axis_char):
-    d=bpy.app.driver_namespace.get(_driver_key())
-    if not d: return (1.0,0.0,0.0,0.0)[int(comp_index)%4]
-    th=sg_theta(side, frame)
-    ux,uy,uz=_axis_unit(axis_char); h=0.5*th; s=sin(h); c=cos(h)
-    q_spin=(c,ux*s,uy*s,uz*s)
-    q_rest=d['restL'] if side=='L' else d['restR']
-    aw,ax,ay,az=q_rest; bw,bx,by,bz=q_spin
-    q=(aw*bw-ax*bx-ay*by-az*bz,
-       aw*bx+ax*bw+ay*bz-az*by,
-       aw*by-ax*bz+ay*bw+az*bx,
-       aw*bz+ax*by-ay*bx+az*bw)
-    return q[int(comp_index)%4]
+    d = bpy.app.driver_namespace.get(_driver_key())
+    if not d:
+        return (1.0, 0.0, 0.0, 0.0)[int(comp_index) % 4]
+    th = sg_theta(side, frame)
+    ux, uy, uz = _axis_unit(axis_char)
+    h = 0.5 * th; s = sin(h); c = cos(h)
+    q_spin = (c, ux*s, uy*s, uz*s)
+    aw, ax, ay, az = _rest_quat_for(d, side)
+    bw, bx, by, bz = q_spin
+    q = (aw*bw - ax*bx - ay*by - az*bz,
+         aw*bx + ax*bw + ay*bz - az*by,
+         aw*by - ax*bz + ay*bw + az*bx,
+         aw*bz + ax*by - ay*bx + az*bw)
+    return q[int(comp_index) % 4]
 
 def sg_quat_comp_obj(side, frame, comp_index, axis_char, rw, rx, ry, rz):
     d=bpy.app.driver_namespace.get(_driver_key())
@@ -776,56 +1060,616 @@ bpy.app.driver_namespace['sg_theta']=sg_theta
 bpy.app.driver_namespace['sg_quat_comp']=sg_quat_comp
 bpy.app.driver_namespace['sg_quat_comp_obj']=sg_quat_comp_obj
 
+# ---------------------- viewport visualization ----------------------
+# Thin GPU-drawn construction lines shown in every 3D View. Every time a
+# related property changes, its update callback taggs the viewport for
+# redraw, so the overlay follows the settings live.
+import gpu
+from gpu_extras.batch import batch_for_shader
+
+_DRAW_HANDLE = None
+
+# Colors are RGBA; alpha < 1 keeps them visibly "construction line" looking.
+_CLR_FWD    = (0.30, 1.00, 0.35, 0.90)  # body forward axis (green)
+_CLR_L      = (1.00, 0.35, 0.35, 0.90)  # left wheels (red)
+_CLR_R      = (0.35, 0.55, 1.00, 0.90)  # right wheels (blue)
+_CLR_C      = (1.00, 0.85, 0.20, 0.90)  # caster wheel (yellow)
+_CLR_PATH_R = (1.00, 0.55, 0.10, 0.80)  # raw path (orange)
+_CLR_PATH_S = (0.15, 0.85, 1.00, 0.90)  # solution path (cyan)
+
+
+def _tag_viewport_redraw(_self=None, _ctx=None):
+    """update= callback: mark every 3D viewport for a redraw."""
+    try:
+        wm = bpy.context.window_manager
+        for w in wm.windows:
+            for a in w.screen.areas:
+                if a.type == 'VIEW_3D':
+                    a.tag_redraw()
+    except Exception:
+        pass
+
+
+def _apply_scale_rot_mesh(obj):
+    """
+    Bake scale and rotation into obj's mesh, preserving world location.
+    Runs at the data level (no operator) so it is safe from a property
+    update callback. Skips objects that would be surprising to modify:
+    non-mesh, parented, shared-mesh, animated, or already identity.
+    """
+    if obj is None or obj.type != 'MESH':
+        return False
+    if obj.parent is not None:
+        return False
+    if obj.animation_data is not None and obj.animation_data.action is not None:
+        return False
+    mesh = obj.data
+    if mesh is None:
+        return False
+    if getattr(mesh, "users", 1) > 1:
+        return False
+
+    scale_ok = all(abs(s - 1.0) < 1e-6 for s in obj.scale)
+    rot_ok = all(abs(r) < 1e-6 for r in obj.rotation_euler) and \
+             (obj.rotation_mode != 'QUATERNION' or (
+                abs(obj.rotation_quaternion[0] - 1.0) < 1e-6 and
+                all(abs(q) < 1e-6 for q in obj.rotation_quaternion[1:])))
+    if scale_ok and rot_ok:
+        return False
+
+    if getattr(bpy.context, "mode", "OBJECT") != 'OBJECT':
+        return False
+
+    # matrix_basis = T * R * S in the object's own local frame; strip T,
+    # transform the mesh by what remains, then reset R and S.
+    mat = obj.matrix_basis.copy()
+    mat.translation = (0.0, 0.0, 0.0)
+    mesh.transform(mat)
+    try:
+        mesh.update()
+    except Exception:
+        pass
+
+    obj.rotation_euler = (0.0, 0.0, 0.0)
+    obj.rotation_quaternion = (1.0, 0.0, 0.0, 0.0)
+    obj.scale = (1.0, 1.0, 1.0)
+    return True
+
+
+def _on_object_assigned(self, context):
+    """PointerProperty update: viewport redraw + bake scale/rotation."""
+    _tag_viewport_redraw(self, context)
+    for prop in ("chassis",
+                 "wheel_l_01", "wheel_l_02", "wheel_l_03",
+                 "wheel_r_01", "wheel_r_02", "wheel_r_03",
+                 "wheel_caster"):
+        obj = getattr(self, prop, None)
+        if obj is not None:
+            _apply_scale_rot_mesh(obj)
+
+
+def _on_body_forward_changed(self, context):
+    """Auto-set wheel_axis perpendicular to body forward, plus viewport redraw."""
+    _tag_viewport_redraw(self, context)
+    fa = getattr(self, "body_forward_axis", "+Y")
+    perp = 'Y' if fa in ('+X', '-X') else 'X'
+    if self.wheel_axis != perp:
+        self.wheel_axis = perp
+
+
+def _axis_char_from_body_forward(fa):
+    """Map '+Y'/'-X'/... to just the axis character."""
+    return fa[-1] if fa and len(fa) >= 2 else 'Y'
+
+
+def _iter_location_fcurves(ch):
+    """Return (fc_x, fc_y, fc_z) triple or Nones for chassis location."""
+    fcs = [None, None, None]
+    if not ch or not ch.animation_data or not ch.animation_data.action:
+        return fcs
+    for fc in _iter_action_fcurves(ch.animation_data.action):
+        if fc.data_path == "location" and 0 <= fc.array_index <= 2:
+            fcs[fc.array_index] = fc
+    return fcs
+
+
+def _chassis_keyframe_positions(ch):
+    """List of (x, y, z) at every location keyframe on the chassis."""
+    fcs = _iter_location_fcurves(ch)
+    if not any(fcs):
+        return []
+    frames = set()
+    for fc in fcs:
+        if fc:
+            for kp in fc.keyframe_points:
+                frames.add(int(round(kp.co[0])))
+    out = []
+    for f in sorted(frames):
+        x = fcs[0].evaluate(f) if fcs[0] else 0.0
+        y = fcs[1].evaluate(f) if fcs[1] else 0.0
+        z = fcs[2].evaluate(f) if fcs[2] else 0.0
+        out.append((x, y, z))
+    return out
+
+
+def _chassis_backup_positions(ch):
+    """List of (x, y, z) waypoints stored by the autocorrect backup, if any."""
+    if not ch:
+        return []
+    key = f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
+    txt = bpy.data.texts.get(key)
+    if not txt or not txt.as_string():
+        return []
+    try:
+        data = json.loads(txt.as_string())
+    except Exception:
+        return []
+    channels = {0: {}, 1: {}, 2: {}}
+    frames = set()
+    for k, rows in data.items():
+        if k.startswith("location["):
+            try:
+                idx = int(k.split("[")[1][0])
+            except Exception:
+                continue
+            if idx not in channels:
+                continue
+            for fr, val in rows:
+                channels[idx][int(round(fr))] = float(val)
+                frames.add(int(round(fr)))
+    out = []
+    last = [0.0, 0.0, 0.0]
+    for f in sorted(frames):
+        for i in range(3):
+            if f in channels[i]:
+                last[i] = channels[i][f]
+        out.append((last[0], last[1], last[2]))
+    return out
+
+
+def _chassis_smooth_path(ch, f0, f1, step=1):
+    """Dense sample of the current chassis fcurve interpolation."""
+    fcs = _iter_location_fcurves(ch)
+    if not any(fcs):
+        return []
+    pts = []
+    for f in range(int(f0), int(f1) + 1, step):
+        x = fcs[0].evaluate(f) if fcs[0] else 0.0
+        y = fcs[1].evaluate(f) if fcs[1] else 0.0
+        z = fcs[2].evaluate(f) if fcs[2] else 0.0
+        pts.append((x, y, z))
+    return pts
+
+
+def _draw_lines(pairs, color, width=1.5):
+    """Draw a list of ((x,y,z),(x,y,z)) segments in one batch."""
+    if not pairs:
+        return
+    verts = []
+    for a, b in pairs:
+        verts.append(tuple(a)); verts.append(tuple(b))
+    shader = gpu.shader.from_builtin('UNIFORM_COLOR')
+    batch = batch_for_shader(shader, 'LINES', {"pos": verts})
+    prev_lw = 1.0
+    try:
+        gpu.state.line_width_set(width)
+        shader.bind()
+        shader.uniform_float("color", color)
+        batch.draw(shader)
+    finally:
+        gpu.state.line_width_set(prev_lw)
+
+
+def _draw_polyline(pts, color, width=1.5):
+    if len(pts) < 2:
+        return
+    shader = gpu.shader.from_builtin('UNIFORM_COLOR')
+    batch = batch_for_shader(shader, 'LINE_STRIP', {"pos": [tuple(p) for p in pts]})
+    try:
+        gpu.state.line_width_set(width)
+        shader.bind()
+        shader.uniform_float("color", color)
+        batch.draw(shader)
+    finally:
+        gpu.state.line_width_set(1.0)
+
+
+def _draw_points(pts, color, size=7.0):
+    if not pts:
+        return
+    shader = gpu.shader.from_builtin('UNIFORM_COLOR')
+    batch = batch_for_shader(shader, 'POINTS', {"pos": [tuple(p) for p in pts]})
+    try:
+        gpu.state.point_size_set(size)
+        shader.bind()
+        shader.uniform_float("color", color)
+        batch.draw(shader)
+    finally:
+        gpu.state.point_size_set(1.0)
+
+
+def _forward_axis_world(ch, body_forward_axis, length):
+    """Return (origin, tip, tick_a, tick_b) in world space for the forward-axis arrow."""
+    axis_char = _axis_char_from_body_forward(body_forward_axis)
+    sgn = -1.0 if body_forward_axis.startswith('-') else 1.0
+    lv = _axis_unit(axis_char)
+    local = Vector((lv[0] * sgn, lv[1] * sgn, lv[2] * sgn))
+    m3 = ch.matrix_world.to_3x3()
+    world = m3 @ local
+    if world.length < 1e-9:
+        world = Vector((0.0, 1.0, 0.0))
+    world.normalize()
+    origin = ch.matrix_world.translation.copy()
+    tip = origin + world * length
+    # Arrow-head perpendicular in the local XY of the arrow.
+    up = Vector((0.0, 0.0, 1.0))
+    perp = world.cross(up)
+    if perp.length < 1e-6:
+        perp = Vector((1.0, 0.0, 0.0))
+    perp.normalize()
+    head = length * 0.18
+    a = tip - world * head + perp * head * 0.55
+    b = tip - world * head - perp * head * 0.55
+    return origin, tip, a, b
+
+
+def _wheel_axis_segments(obj, wheel_axis_char, side):
+    """
+    Build the segments for one wheel's rotation-axis gizmo:
+      - a line along the rotation axis, total length ~= 2 * tire width
+      - a small perpendicular tick at the (+) end of the axis, indicating
+        the positive-theta side by the right-hand rule
+    """
+    if not obj:
+        return []
+    m3 = obj.matrix_world.to_3x3()
+    lv = _axis_unit(wheel_axis_char)
+    world_axis = m3 @ Vector(lv)
+    if world_axis.length < 1e-9:
+        world_axis = Vector((0.0, 1.0, 0.0))
+    world_axis.normalize()
+
+    # Estimate tire width as the smallest bbox dimension of the wheel.
+    # For a typical cylindrical wheel this is the width along the axle.
+    dims = obj.dimensions
+    tire_w = max(min(dims.x, dims.y, dims.z), 0.02)
+    half = tire_w  # so total axis line = 2 * tire_w
+    center = obj.matrix_world.translation.copy()
+    a = center - world_axis * half
+    b = center + world_axis * half
+
+    up = Vector((0.0, 0.0, 1.0))
+    tick = world_axis.cross(up)
+    if tick.length < 1e-6:
+        tick = Vector((1.0, 0.0, 0.0))
+    tick.normalize()
+    tick_len = tire_w * 0.4
+    t1 = b + tick * tick_len
+    t2 = b - tick * tick_len
+
+    return [(a, b), (b, t1), (b, t2)]
+
+
+def _draw_body_forward(P):
+    ch = P.chassis
+    if not ch:
+        return
+    length = max(_effective_track_width(P) * 2.5, 0.5)
+    origin, tip, a, b = _forward_axis_world(ch, P.body_forward_axis, length)
+    _draw_lines([(origin, tip), (tip, a), (tip, b)], _CLR_FWD, width=2.0)
+
+
+def _draw_all_wheels(P):
+    wa = P.wheel_axis
+    segs_L = []
+    for obj in _iter_side(P, 'L'):
+        segs_L.extend(_wheel_axis_segments(obj, wa, 'L'))
+    segs_R = []
+    for obj in _iter_side(P, 'R'):
+        segs_R.extend(_wheel_axis_segments(obj, wa, 'R'))
+    segs_C = []
+    for obj in _iter_side(P, 'C'):
+        segs_C.extend(_wheel_axis_segments(obj, wa, 'C'))
+
+    _draw_lines(segs_L, _CLR_L, width=1.8)
+    _draw_lines(segs_R, _CLR_R, width=1.8)
+    _draw_lines(segs_C, _CLR_C, width=1.8)
+
+
+def _preview_key_poses(P, ch):
+    """
+    Waypoints (frame, x, y, z, yaw, heading) read directly from the chassis
+    fcurves via fc.evaluate. Cheap enough for viewport redraws. Supports
+    Euler and Quaternion rotation.
+    """
+    if not ch or not ch.animation_data or not ch.animation_data.action:
+        return []
+    act = ch.animation_data.action
+    loc = [None, None, None]
+    reul = [None, None, None]
+    quat = [None, None, None, None]
+    for fc in _iter_action_fcurves(act):
+        if fc.data_path == "location" and 0 <= fc.array_index <= 2:
+            loc[fc.array_index] = fc
+        elif fc.data_path == "rotation_euler" and 0 <= fc.array_index <= 2:
+            reul[fc.array_index] = fc
+        elif fc.data_path == "rotation_quaternion" and 0 <= fc.array_index <= 3:
+            quat[fc.array_index] = fc
+    if not any(loc):
+        return []
+    frames = set()
+    for fc in loc + reul + list(quat):
+        if fc:
+            for kp in fc.keyframe_points:
+                frames.add(int(round(kp.co[0])))
+    out = []
+    for f in sorted(frames):
+        x = loc[0].evaluate(f) if loc[0] else 0.0
+        y = loc[1].evaluate(f) if loc[1] else 0.0
+        z = loc[2].evaluate(f) if loc[2] else 0.0
+        if reul[2] is not None:
+            yaw = reul[2].evaluate(f)
+        elif all(quat):
+            qw = quat[0].evaluate(f); qx = quat[1].evaluate(f)
+            qy = quat[2].evaluate(f); qz = quat[3].evaluate(f)
+            yaw = atan2(2.0 * (qw * qz + qx * qy),
+                        1.0 - 2.0 * (qy * qy + qz * qz))
+        else:
+            yaw = 0.0
+        heading = yaw_to_heading(P, yaw)
+        out.append((f, x, y, z, yaw, heading))
+    return out
+
+
+def _preview_backup_poses(P, ch):
+    """(frame, x, y, z, yaw, heading) reconstructed from the autocorrect backup Text."""
+    if not ch:
+        return []
+    key = f"{_BACKUP_KEY}_{bpy.context.scene.name}_{ch.name}"
+    txt = bpy.data.texts.get(key)
+    if not txt or not txt.as_string():
+        return []
+    try:
+        data = json.loads(txt.as_string())
+    except Exception:
+        return []
+    loc_ch = {0: {}, 1: {}, 2: {}}
+    yaw_map = {}
+    frames = set()
+    for k, rows in data.items():
+        if k.startswith("location["):
+            try:
+                idx = int(k.split("[")[1][0])
+            except Exception:
+                continue
+            if idx not in loc_ch:
+                continue
+            for fr, val in rows:
+                loc_ch[idx][int(round(fr))] = float(val)
+                frames.add(int(round(fr)))
+        elif k == "rotation_euler[2]":
+            for fr, val in rows:
+                yaw_map[int(round(fr))] = float(val)
+                frames.add(int(round(fr)))
+    out = []
+    lx = ly = lz = 0.0
+    lyaw = 0.0
+    for f in sorted(frames):
+        if f in loc_ch[0]: lx = loc_ch[0][f]
+        if f in loc_ch[1]: ly = loc_ch[1][f]
+        if f in loc_ch[2]: lz = loc_ch[2][f]
+        if f in yaw_map:   lyaw = yaw_map[f]
+        out.append((f, lx, ly, lz, lyaw, yaw_to_heading(P, lyaw)))
+    return out
+
+
+def _preview_sease_geometry(P, poses, steps_per_seg=32):
+    """
+    Sample the S-Ease Bezier curve geometry (no timing) so the preview
+    reflects Tangent Scale Start / End and body forward immediately.
+    """
+    tangent_start = P.bezier_tangent_start
+    tangent_end   = P.bezier_tangent_end
+    pts = []
+    for i in range(len(poses) - 1):
+        _fA, xA, yA, zA, _yA, hA = poses[i]
+        _fB, xB, yB, zB, _yB, hB = poses[i + 1]
+        P0, P1, P2, P3 = _build_s_ease_curve_segment(
+            (xA, yA, hA), (xB, yB, hB), tangent_start, tangent_end)
+        for s in range(steps_per_seg + 1):
+            t = s / steps_per_seg
+            pt = _bezier_point_xy(P0, P1, P2, P3, t)
+            z = _lerp(zA, zB, t)
+            # Skip duplicate junction point when we start the next segment.
+            if pts and s == 0:
+                continue
+            pts.append((pt.x, pt.y, z))
+    return pts
+
+
+def _preview_linear_geometry(_P, poses):
+    """Linear autocorrect is a straight polyline through the waypoints."""
+    return [(x, y, z) for (_f, x, y, z, _yaw, _h) in poses]
+
+
+def _preview_solution_path(P, ch):
+    """
+    Solution path preview:
+    - autocorrect OFF: sample the CURRENT chassis fcurves (baked animation).
+    - autocorrect SEASE: geometry of the S-Ease Bezier segments.
+    - autocorrect LINEAR: straight polyline through waypoints.
+    Waypoints come from the autocorrect backup when present so the preview
+    tracks the user's original intent even after a bake.
+    """
+    if not ch:
+        return []
+    mode = P.autocorrect_mode
+    if mode == 'OFF':
+        scn = bpy.context.scene
+        return _chassis_smooth_path(ch, int(scn.frame_start), int(scn.frame_end), step=1)
+    poses = _preview_backup_poses(P, ch) or _preview_key_poses(P, ch)
+    if len(poses) < 2:
+        return []
+    if mode == 'SEASE':
+        return _preview_sease_geometry(P, poses)
+    if mode == 'LINEAR':
+        return _preview_linear_geometry(P, poses)
+    return []
+
+
+def _draw_paths(P):
+    ch = P.chassis
+    if not ch:
+        return
+
+    if P.vis_show_raw_path:
+        backup = _chassis_backup_positions(ch)
+        raw_pts = backup or _chassis_keyframe_positions(ch)
+        if raw_pts:
+            _draw_polyline(raw_pts, _CLR_PATH_R, width=1.2)
+            _draw_points(raw_pts, _CLR_PATH_R, size=8.0)
+
+    if P.vis_show_solution_path:
+        sol = _preview_solution_path(P, ch)
+        if sol:
+            _draw_polyline(sol, _CLR_PATH_S, width=2.0)
+
+
+def _draw_handler():
+    try:
+        P = bpy.context.scene.sg_props
+    except Exception:
+        return
+    if not getattr(P, "vis_enabled", True):
+        return
+
+    # Preserve GPU state so we don't leak into other overlays.
+    prev_blend = gpu.state.blend_get()
+    prev_depth = gpu.state.depth_test_get()
+    gpu.state.blend_set('ALPHA')
+    gpu.state.depth_test_set('NONE')  # construction lines show through geometry
+
+    try:
+        if P.vis_show_forward:
+            _draw_body_forward(P)
+        if P.vis_show_wheels:
+            _draw_all_wheels(P)
+        if P.vis_show_raw_path or P.vis_show_solution_path:
+            _draw_paths(P)
+    finally:
+        gpu.state.blend_set(prev_blend)
+        gpu.state.depth_test_set(prev_depth)
+
+
+def _register_draw_handler():
+    global _DRAW_HANDLE
+    if _DRAW_HANDLE is None:
+        _DRAW_HANDLE = bpy.types.SpaceView3D.draw_handler_add(
+            _draw_handler, (), 'WINDOW', 'POST_VIEW')
+
+
+def _unregister_draw_handler():
+    global _DRAW_HANDLE
+    if _DRAW_HANDLE is not None:
+        try:
+            bpy.types.SpaceView3D.draw_handler_remove(_DRAW_HANDLE, 'WINDOW')
+        except Exception:
+            pass
+        _DRAW_HANDLE = None
+
+
 # ---------------------- properties ----------------------
 class SG_Props(bpy.types.PropertyGroup):
     # Selection
-    chassis: bpy.props.PointerProperty(name="Chassis (animated)", type=bpy.types.Object)
-    right_collection: bpy.props.PointerProperty(name="Right Wheels (Collection)", type=bpy.types.Collection)
-    left_collection: bpy.props.PointerProperty(name="Left Wheels (Collection)", type=bpy.types.Collection)
-    swap_lr: bpy.props.BoolProperty(name="Swap L/R Sides", default=False)
+    chassis: bpy.props.PointerProperty(name="Chassis (animated)", type=bpy.types.Object, update=_on_object_assigned)
+
+    num_wheels: bpy.props.EnumProperty(
+        name="Wheel Configuration",
+        description="Number and layout of the driven / passive wheels",
+        items=[
+            ('2', "2 (Diff Drive)",       "1 driven wheel per side"),
+            ('3', "3 (Diff + Caster)",    "1 driven wheel per side plus a passive caster / omni wheel"),
+            ('4', "4 (Skid Steer)",       "2 driven wheels per side, same speed on each side"),
+            ('6', "6 (Rocker / Rover)",   "3 driven wheels per side, same speed on each side"),
+        ],
+        default='2',
+        update=_tag_viewport_redraw,
+    )
+
+    # Individual wheel object slots. Only the ones needed by num_wheels are
+    # shown in the UI; the rest are ignored.
+    wheel_l_01: bpy.props.PointerProperty(name="Left Wheel 01",  type=bpy.types.Object, update=_on_object_assigned)
+    wheel_l_02: bpy.props.PointerProperty(name="Left Wheel 02",  type=bpy.types.Object, update=_on_object_assigned)
+    wheel_l_03: bpy.props.PointerProperty(name="Left Wheel 03",  type=bpy.types.Object, update=_on_object_assigned)
+    wheel_r_01: bpy.props.PointerProperty(name="Right Wheel 01", type=bpy.types.Object, update=_on_object_assigned)
+    wheel_r_02: bpy.props.PointerProperty(name="Right Wheel 02", type=bpy.types.Object, update=_on_object_assigned)
+    wheel_r_03: bpy.props.PointerProperty(name="Right Wheel 03", type=bpy.types.Object, update=_on_object_assigned)
+    wheel_caster: bpy.props.PointerProperty(name="Caster Wheel", type=bpy.types.Object, update=_on_object_assigned)
+
+    swap_lr: bpy.props.BoolProperty(
+        name="Swap L/R Sides",
+        description="Swap the roles of the left and right wheel slots without re-assigning them",
+        default=False,
+        update=_tag_viewport_redraw,
+    )
 
     # Geometry / wheels
-    track_width: bpy.props.FloatProperty(name="Track Width (m)", default=0.25, min=1e-5, precision=5)
-    tire_spacing: bpy.props.FloatProperty(name="Distance Between Tires (m)", default=0.40, min=0.0, precision=5)
-    auto_radius: bpy.props.BoolProperty(name="Auto-detect Wheel Radius", default=True)
-    wheel_radius: bpy.props.FloatProperty(name="Wheel Radius (m)", default=0.06, min=1e-5, precision=5)
-    wheel_axis: bpy.props.EnumProperty(name="Wheel Rotation Axis", items=[('X','X',''),('Y','Y',''),('Z','Z','')], default='X')
-    rotation_mode: bpy.props.EnumProperty(name="Rotation Mode", items=[('EULER','Euler',''),('QUAT','Quaternion','')], default='EULER')
-    sign_r: bpy.props.EnumProperty(name="Right Wheel Direction", items=[('PLUS','Forward (+1)',''),('MINUS','Inverted (-1)','')], default='PLUS')
-    sign_l: bpy.props.EnumProperty(name="Left Wheel Direction", items=[('PLUS','Forward (+1)',''),('MINUS','Inverted (-1)','')], default='PLUS')
-
-    wheel_forward_invert: bpy.props.BoolProperty(
-        name="Invert Wheel Forward",
-        description="Flip wheel rolling direction relative to body forward (use if the model's front faces the opposite axis)",
-        default=False,
+    auto_track_width: bpy.props.BoolProperty(
+        name="Auto Track Width",
+        description="Measure track width as the world distance between Left Wheel 01 and Right Wheel 01",
+        default=True, update=_tag_viewport_redraw,
     )
+    track_width: bpy.props.FloatProperty(
+        name="Track Width (m)",
+        description="Center-to-center distance between the left and right wheels along the axle",
+        default=0.25, min=1e-5, precision=5, update=_tag_viewport_redraw,
+    )
+    auto_radius: bpy.props.BoolProperty(name="Auto Wheel Radius", default=True)
+    wheel_radius: bpy.props.FloatProperty(name="Wheel Radius (m)", default=0.06, min=1e-5, precision=5)
+    wheel_axis: bpy.props.EnumProperty(
+        name="Wheel Rotation Axis",
+        description="Local axis the wheels spin around. Auto-set to be perpendicular to Body Forward Axis",
+        items=[('X','X',''),('Y','Y',''),('Z','Z','')],
+        default='X', update=_tag_viewport_redraw,
+    )
+    rotation_mode: bpy.props.EnumProperty(name="Rotation Mode", items=[('EULER','Euler',''),('QUAT','Quaternion','')], default='EULER')
 
     # Feasibility / Autocorrect
     body_forward_axis: bpy.props.EnumProperty(
         name="Body Forward Axis",
         items=[('+X','Local +X',''), ('-X','Local -X',''), ('+Y','Local +Y',''), ('-Y','Local -Y','')],
-        default='+Y'
+        default='+Y',
+        update=_on_body_forward_changed,
     )
     side_tol: bpy.props.FloatProperty(name="Sideways Tolerance (m/s)", default=0.02, min=0.0, precision=6)
 
     autocorrect_mode: bpy.props.EnumProperty(
-        name="Autocorrect Mode (Path Geometry)",
+        name="Autocorrect Mode",
         items=[
             ('OFF','Off',''),
             ('SEASE','Smooth Curve (S-Ease)','Smooth Bezier segments with curvature clamp'),
-            ('LINEAR','Linear (Rotate–Move–Rotate)','Rotate to face, move straight, rotate to final'),
+            ('LINEAR','Linear (Rotate-Move-Rotate)','Rotate to face, move straight, rotate to final'),
         ],
         default='SEASE',
+        update=_tag_viewport_redraw,
     )
-    bezier_tangent_scale: bpy.props.FloatProperty(
-        name="Tangent Scale (S-Ease)",
-        description="Handle length as fraction of pose distance (larger = rounder arcs). Curvature is clamped by track_width/2.",
-        default=0.35, min=0.05, max=2.0, precision=3
+    bezier_tangent_start: bpy.props.FloatProperty(
+        name="Tangent Scale Start",
+        description="Length of the start-handle (P1) of each Bezier segment as a fraction of the pose distance. Larger = the curve leaves the start waypoint with a bigger swing",
+        default=0.35, min=0.0, max=0.49, precision=3,
+        update=_tag_viewport_redraw,
+    )
+    bezier_tangent_end: bpy.props.FloatProperty(
+        name="Tangent Scale End",
+        description="Length of the end-handle (P2) of each Bezier segment as a fraction of the pose distance. Larger = the curve approaches the end waypoint with a bigger swing",
+        default=0.35, min=0.0, max=0.49, precision=3,
+        update=_tag_viewport_redraw,
     )
     linear_rotation_fraction: bpy.props.FloatProperty(
-        name="Rotation Fraction (Linear)",
-        description="Per segment, fraction of frames used for the initial and final rotations (each).",
-        default=0.25, min=0.0, max=0.45, precision=3
+        name="Rotation Fraction",
+        description="Per segment, fraction of frames used for the initial and final rotations (each)",
+        default=0.25, min=0.0, max=0.45, precision=3,
+        update=_tag_viewport_redraw,
     )
 
     # Speed profiles
@@ -833,8 +1677,8 @@ class SG_Props(bpy.types.PropertyGroup):
         name="Speed Profile (Timing)",
         items=[
             ('CONSTANT',     "Constant (Uniform+Ramps)",    "Constant speed with ramps (linear accel/decel)"),
-            ('GLOBAL_EASE',  "Ease — Whole Timeline",       "Slow-in/fast/slow-out across the entire timeline"),
-            ('PER_KEY_EASE', "Ease — Per Keyframe Segment", "Each keyframe-to-keyframe segment eases (single slider)"),
+            ('GLOBAL_EASE',  "Ease - Whole Timeline",       "Slow-in/fast/slow-out across the entire timeline"),
+            ('PER_KEY_EASE', "Ease - Per Keyframe Segment", "Each keyframe-to-keyframe segment eases (single slider)"),
         ],
         default='CONSTANT',
     )
@@ -880,15 +1724,51 @@ class SG_Props(bpy.types.PropertyGroup):
     csv_import_path: bpy.props.StringProperty(name="CSV Import File", default="//import_anim.csv", subtype='FILE_PATH')
     csv_import_skip_rows: bpy.props.IntProperty(name="Skip Rows from Top", default=2, min=0, max=100, description="Number of header/metadata rows to skip")
 
-    # UI foldouts
-    show_instructions: bpy.props.BoolProperty(name="Show Instructions", default=False)
-    show_selection:   bpy.props.BoolProperty(name="Show Object Selection", default=True)
-    show_calibration: bpy.props.BoolProperty(name="Show Calibration", default=False)
-    show_csv_import:  bpy.props.BoolProperty(name="Show Import Animation by CSV", default=False)
-    show_feasibility: bpy.props.BoolProperty(name="Show Feasibility", default=True)
-    show_rpm_calc:    bpy.props.BoolProperty(name="Show RPM Calculation", default=False)
-    show_anim_export: bpy.props.BoolProperty(name="Show Animation Data Export", default=False)
-    show_csv_export:  bpy.props.BoolProperty(name="Show CSV Engineering Export", default=False)
+    # UI foldouts (kept in scene so they persist per-file)
+    show_instructions:  bpy.props.BoolProperty(name="Show Instructions",       default=False)
+    show_viewport:      bpy.props.BoolProperty(name="Show Viewport Helpers",   default=True)
+    show_setup:         bpy.props.BoolProperty(name="Show Rig Setup",          default=True)
+    show_calibration:   bpy.props.BoolProperty(name="Show Calibration",        default=False)
+    show_motion:        bpy.props.BoolProperty(name="Show Motion Path",        default=True)
+    show_drivers:       bpy.props.BoolProperty(name="Show Wheel Drivers",      default=True)
+    show_io:            bpy.props.BoolProperty(name="Show Import / Export",    default=False)
+
+    io_mode: bpy.props.EnumProperty(
+        name="Operation",
+        items=[
+            ('IMPORT', "Import CSV",         "Read a chassis + wheel trajectory back from CSV"),
+            ('KEYS',   "Export Keyframes",   "Snapshot keyframe rows to CSV or JSON"),
+            ('CSV',    "Engineering CSV",    "Continuous time-series CSV at scene or fixed rate"),
+        ],
+        default='CSV',
+    )
+
+    # Viewport visualization toggles
+    vis_enabled: bpy.props.BoolProperty(
+        name="Enable Overlay",
+        description="Master toggle for all viewport construction lines drawn by this add-on",
+        default=True, update=_tag_viewport_redraw,
+    )
+    vis_show_forward: bpy.props.BoolProperty(
+        name="Body Forward Axis",
+        description="Green arrow from the chassis along the chosen Body Forward Axis",
+        default=True, update=_tag_viewport_redraw,
+    )
+    vis_show_wheels: bpy.props.BoolProperty(
+        name="Wheel Rotation Axes",
+        description="Colored axis line through each configured wheel (L red, R blue, caster yellow)",
+        default=True, update=_tag_viewport_redraw,
+    )
+    vis_show_raw_path: bpy.props.BoolProperty(
+        name="Raw Path",
+        description="Orange polyline through the chassis keyframes (uses autocorrect backup when present)",
+        default=True, update=_tag_viewport_redraw,
+    )
+    vis_show_solution_path: bpy.props.BoolProperty(
+        name="Solution Path",
+        description="Cyan curve sampling the current chassis animation across every frame",
+        default=True, update=_tag_viewport_redraw,
+    )
 
     # Keyframe export
     other_export_path: bpy.props.StringProperty(name="Anim Data File", default="//anim_keyframes.csv", subtype='FILE_PATH')
@@ -931,10 +1811,10 @@ class SG_OT_AutocorrectSEase(bpy.types.Operator):
         self.report({'INFO'}, f"Autocorrect baked {n} frames. Re-run Validate Motion."); return {'FINISHED'}
 
 class SG_OT_AutocorrectLinear(bpy.types.Operator):
-    bl_idname="segway.autocorrect_linear"; bl_label="Autocorrect & Bake (Linear: Rotate–Move–Rotate)"
+    bl_idname="segway.autocorrect_linear"; bl_label="Autocorrect & Bake (Linear: Rotate-Move-Rotate)"
     def execute(self, context):
         P=context.scene.sg_props
-        if P.autocorrect_mode!='LINEAR': self.report({'ERROR'},"Set Autocorrect Mode to 'Linear (Rotate–Move–Rotate)'."); return {'CANCELLED'}
+        if P.autocorrect_mode!='LINEAR': self.report({'ERROR'},"Set Autocorrect Mode to 'Linear (Rotate-Move-Rotate)'."); return {'CANCELLED'}
         try: n=build_linear_path_and_bake(context)
         except Exception as e: self.report({'ERROR'}, f"Autocorrect failed: {e}"); return {'CANCELLED'}
         self.report({'INFO'}, f"Linear autocorrect baked {n} frames. Re-run Validate Motion."); return {'FINISHED'}
@@ -948,175 +1828,281 @@ class SG_OT_RevertAutocorrect(bpy.types.Operator):
         if not ok: self.report({'ERROR'},"No backup found to restore."); return {'CANCELLED'}
         self.report({'INFO'},"Original chassis keyframes restored."); return {'FINISHED'}
 
+def _active_sides(P):
+    """('L', 'R') for 2/4/6-wheel configs; ('L', 'R', 'C') for the 3-wheel case."""
+    return ('L', 'R', 'C') if _wheel_count(P) == 3 else ('L', 'R')
+
+
 class SG_OT_AttachDrivers(bpy.types.Operator):
-    bl_idname="segway.attach_drivers"; bl_label="Attach Drivers"
+    bl_idname = "segway.attach_drivers"
+    bl_label = "Attach Drivers"
+    bl_description = "Attach rotation drivers to every configured wheel using the current cache"
+
     def execute(self, context):
-        P=context.scene.sg_props
+        P = context.scene.sg_props
         if not bpy.app.driver_namespace.get(_driver_key()):
             self.report({'ERROR'}, "Build Cache first (and pass validation)."); return {'CANCELLED'}
-        axis_i=_AXIS_INDEX[P.wheel_axis]
-        for side in ('L','R'):
+        axis_i = _AXIS_INDEX[P.wheel_axis]
+
+        for side in _active_sides(P):
             for obj in _iter_side(P, side):
-                if P.rotation_mode=='EULER':
-                    _ensure_xyz_euler(obj)
-                    try:
-                        for i in range(4): obj.driver_remove("rotation_quaternion", i)
-                    except Exception: pass
-                    try: obj.driver_remove("rotation_euler", axis_i)
-                    except Exception: pass
-                    dcurve=obj.driver_add("rotation_euler",axis_i); dcurve.driver.type='SCRIPTED'
-                    dcurve.driver.expression=f"sg_theta('{side}', frame)"
-                else:
-                    _ensure_quaternion(obj)
-                    try: obj.driver_remove("rotation_euler", axis_i)
-                    except Exception: pass
-                    try:
-                        for i in range(4): obj.driver_remove("rotation_quaternion", i)
-                    except Exception: pass
-                    for comp in range(4):
-                        dcurve=obj.driver_add("rotation_quaternion",comp); dcurve.driver.type='SCRIPTED'
-                        rq=_obj_rest_quat(obj)
-                        obj['rest_w'], obj['rest_x'], obj['rest_y'], obj['rest_z'] = rq
-                        dcurve.driver.expression=f"sg_quat_comp_obj('{side}', frame, {comp}, '{P.wheel_axis}', rw, rx, ry, rz)"
-                        var=dcurve.driver.variables.new(); var.name='rw'; var.targets[0].id=obj; var.targets[0].data_path='["rest_w"]'
-                        var=dcurve.driver.variables.new(); var.name='rx'; var.targets[0].id=obj; var.targets[0].data_path='["rest_x"]'
-                        var=dcurve.driver.variables.new(); var.name='ry'; var.targets[0].id=obj; var.targets[0].data_path='["rest_y"]'
-                        var=dcurve.driver.variables.new(); var.name='rz'; var.targets[0].id=obj; var.targets[0].data_path='["rest_z"]'
-        self.report({'INFO'}, "Drivers attached to wheel objects."); return {'FINISHED'}
-
-class SG_OT_BuildCache(bpy.types.Operator):
-    bl_idname="segway.build_cache"; bl_label="Build Cache"
-    def execute(self, context):
-        try: d=build_cache(context)
-        except Exception as e: self.report({'ERROR'}, str(e)); return {'CANCELLED'}
-        self.report({'INFO'}, f"OK | r={d['radius']:.4f} m | track={d['track']:.4f} m | maxRPM L/R {d['max_rpm_L']:.1f}/{d['max_rpm_R']:.1f}")
-        return {'FINISHED'}
-
-class SG_OT_Bake(bpy.types.Operator):
-    bl_idname="segway.bake_wheels"; bl_label="Bake Wheels"
-    def execute(self, context):
-        P=context.scene.sg_props; d=bpy.app.driver_namespace.get(_driver_key())
-        if not d: self.report({'ERROR'},"Build Cache first (and pass validation)."); return {'CANCELLED'}
-        f0=d['f0']; f1=f0+len(d['thetaL'])-1
-        axis_i=_AXIS_INDEX[P.wheel_axis]; ux,uy,uz=_axis_unit(P.wheel_axis)
-        for side in ('L','R'):
-            arr=d['thetaL'] if side=='L' else d['thetaR']
-            rest=d['restL'] if side=='L' else d['restR']
-            for obj in _iter_side(P,side):
-                if P.rotation_mode=='EULER':
-                    _ensure_xyz_euler(obj)
-                    try: obj.driver_remove("rotation_euler",axis_i)
-                    except Exception: pass
-                else:
-                    _ensure_quaternion(obj)
-                    try:
-                        for i in range(4): obj.driver_remove("rotation_quaternion", i)
-                    except Exception: pass
-                for f in range(f0, f1+1):
-                    i=f-f0; th=arr[i]
-                    if P.rotation_mode=='EULER':
-                        obj.rotation_euler[axis_i]=th
-                        obj.keyframe_insert("rotation_euler", frame=f, index=axis_i)
-                    else:
-                        half=0.5*th; s=sin(half); c=cos(half)
-                        q_spin=(c,ux*s,uy*s,uz*s)
-                        aw,ax,ay,az=rest; bw,bx,by,bz=q_spin
-                        q=(aw*bw-ax*bx-ay*by-az*bz,
-                           aw*bx+ax*bw+ay*bz-az*by,
-                           aw*by-ax*bz+ay*bw+az*bx,
-                           aw*bz+ax*by-ay*bx+az*bw)
-                        rq=obj.rotation_quaternion
-                        rq[0],rq[1],rq[2],rq[3]=q
-                        for comp in range(4): obj.keyframe_insert("rotation_quaternion", frame=f, index=comp)
-        self.report({'INFO'}, f"Baked {f0}..{f1} to keyframes."); return {'FINISHED'}
-
-class SG_OT_Clear(bpy.types.Operator):
-    bl_idname="segway.clear"; bl_label="Clear Drivers/Keyframes"
-    bl_description="Remove wheel rotation drivers AND their rotation keyframes (Euler & Quaternion) on all wheel objects."
-    def execute(self, context):
-        P=context.scene.sg_props; axis_i=_AXIS_INDEX[P.wheel_axis]
-        removed_any=False
-        for side in ('L','R'):
-            for obj in _iter_side(P, side):
-                try: obj.driver_remove("rotation_euler", axis_i); removed_any=True
+                # Wipe any existing rotation drivers on this wheel.
+                try: obj.driver_remove("rotation_euler", axis_i)
                 except Exception: pass
                 try:
-                    for i in range(4): obj.driver_remove("rotation_quaternion", i); removed_any=True
+                    for i in range(4): obj.driver_remove("rotation_quaternion", i)
                 except Exception: pass
-                ad=obj.animation_data
-                if ad and ad.action:
-                    to_del=[fc for fc in ad.action.fcurves
-                            if (fc.data_path=="rotation_euler" and fc.array_index==axis_i)
-                            or fc.data_path=="rotation_quaternion"]
-                    for fc in to_del:
-                        try: ad.action.fcurves.remove(fc); removed_any=True
-                        except Exception: pass
-                if P.rotation_mode=='EULER':
-                    try: obj.rotation_euler[axis_i]=0.0
-                    except Exception: pass
+
+                if P.rotation_mode == 'EULER':
+                    _ensure_xyz_euler(obj)
+                    dcurve = obj.driver_add("rotation_euler", axis_i)
+                    dcurve.driver.type = 'SCRIPTED'
+                    dcurve.driver.expression = f"sg_theta('{side}', frame)"
                 else:
-                    try:
-                        rq=obj.rotation_quaternion
-                        rq[0],rq[1],rq[2],rq[3]=1.0,0.0,0.0,0.0
-                    except Exception: pass
+                    _ensure_quaternion(obj)
+                    # Capture rest BEFORE any driver stubs start evaluating.
+                    rq = _obj_rest_quat(obj)
+                    obj['rest_w'], obj['rest_x'], obj['rest_y'], obj['rest_z'] = rq
+                    for comp in range(4):
+                        dcurve = obj.driver_add("rotation_quaternion", comp)
+                        dcurve.driver.type = 'SCRIPTED'
+                        dcurve.driver.expression = (
+                            f"sg_quat_comp_obj('{side}', frame, {comp}, '{P.wheel_axis}', rw, rx, ry, rz)"
+                        )
+                        for vn, dp in (('rw', '["rest_w"]'), ('rx', '["rest_x"]'),
+                                       ('ry', '["rest_y"]'), ('rz', '["rest_z"]')):
+                            v = dcurve.driver.variables.new()
+                            v.name = vn
+                            v.targets[0].id = obj
+                            v.targets[0].data_path = dp
+
+        self.report({'INFO'}, "Drivers attached to configured wheels.")
+        return {'FINISHED'}
+
+
+class SG_OT_BuildCache(bpy.types.Operator):
+    bl_idname = "segway.build_cache"
+    bl_label = "Build Cache"
+    bl_description = "Integrate chassis motion into per-frame wheel angles and RPM"
+
+    def execute(self, context):
+        try:
+            d = build_cache(context)
+        except Exception as e:
+            self.report({'ERROR'}, str(e)); return {'CANCELLED'}
+        if d.get('num_wheels', 2) == 3:
+            msg = (f"OK | r={d['radius']:.4f} m | track={d['track']:.4f} m | "
+                   f"maxRPM L/R/C {d['max_rpm_L']:.1f}/{d['max_rpm_R']:.1f}/{d['max_rpm_C']:.1f}")
+        else:
+            msg = (f"OK | r={d['radius']:.4f} m | track={d['track']:.4f} m | "
+                   f"maxRPM L/R {d['max_rpm_L']:.1f}/{d['max_rpm_R']:.1f}")
+        self.report({'INFO'}, msg)
+        return {'FINISHED'}
+
+
+class SG_OT_Bake(bpy.types.Operator):
+    bl_idname = "segway.bake_wheels"
+    bl_label = "Bake Wheels"
+    bl_description = "Convert the cached wheel angles into per-frame keyframes on every configured wheel"
+
+    def execute(self, context):
+        P = context.scene.sg_props
+        d = bpy.app.driver_namespace.get(_driver_key())
+        if not d:
+            self.report({'ERROR'}, "Build Cache first (and pass validation).")
+            return {'CANCELLED'}
+
+        f0 = d['f0']; f1 = f0 + len(d['thetaL']) - 1
+        axis_i = _AXIS_INDEX[P.wheel_axis]
+        ux, uy, uz = _axis_unit(P.wheel_axis)
+
+        for side in _active_sides(P):
+            arr = _theta_array_for(d, side)
+            for obj in _iter_side(P, side):
+                # Drop any existing rotation drivers so bake wins.
+                try: obj.driver_remove("rotation_euler", axis_i)
+                except Exception: pass
+                try:
+                    for i in range(4): obj.driver_remove("rotation_quaternion", i)
+                except Exception: pass
+
+                if P.rotation_mode == 'EULER':
+                    _ensure_xyz_euler(obj)
+                else:
+                    _ensure_quaternion(obj)
+
+                # Capture per-wheel rest BEFORE we start writing spin values,
+                # so every frame uses the same base orientation.
+                rest = _obj_rest_quat(obj)
+                for f in range(f0, f1 + 1):
+                    i = f - f0; th = arr[i]
+                    if P.rotation_mode == 'EULER':
+                        obj.rotation_euler[axis_i] = th
+                        obj.keyframe_insert("rotation_euler", frame=f, index=axis_i)
+                    else:
+                        half = 0.5 * th; s = sin(half); c = cos(half)
+                        q_spin = (c, ux*s, uy*s, uz*s)
+                        aw, ax, ay, az = rest
+                        bw, bx, by, bz = q_spin
+                        q = (aw*bw - ax*bx - ay*by - az*bz,
+                             aw*bx + ax*bw + ay*bz - az*by,
+                             aw*by - ax*bz + ay*bw + az*bx,
+                             aw*bz + ax*by - ay*bx + az*bw)
+                        rq = obj.rotation_quaternion
+                        rq[0], rq[1], rq[2], rq[3] = q
+                        for comp in range(4):
+                            obj.keyframe_insert("rotation_quaternion", frame=f, index=comp)
+
+        self.report({'INFO'}, f"Baked frames {f0}..{f1}.")
+        return {'FINISHED'}
+
+class SG_OT_Clear(bpy.types.Operator):
+    bl_idname = "segway.clear"
+    bl_label = "Clear Drivers / Keys"
+    bl_description = "Remove rotation drivers and rotation keyframes from every configured wheel"
+
+    def execute(self, context):
+        P = context.scene.sg_props
+        axis_i = _AXIS_INDEX[P.wheel_axis]
+        removed_any = False
+
+        for obj in _iter_all_wheels(P):
+            try: obj.driver_remove("rotation_euler", axis_i); removed_any = True
+            except Exception: pass
+            try:
+                for i in range(4): obj.driver_remove("rotation_quaternion", i); removed_any = True
+            except Exception: pass
+
+            ad = obj.animation_data
+            if ad and ad.action:
+                to_del = [fc for fc in _iter_action_fcurves(ad.action)
+                          if (fc.data_path == "rotation_euler" and fc.array_index == axis_i)
+                          or fc.data_path == "rotation_quaternion"]
+                for fc in to_del:
+                    _remove_action_fcurve(ad.action, fc); removed_any = True
+
+            if P.rotation_mode == 'EULER':
+                try: obj.rotation_euler[axis_i] = 0.0
+                except Exception: pass
+            else:
+                try:
+                    rq = obj.rotation_quaternion
+                    rq[0], rq[1], rq[2], rq[3] = 1.0, 0.0, 0.0, 0.0
+                except Exception: pass
+
         self.report({'INFO'} if removed_any else {'WARNING'},
-                    "Cleared drivers & rotation keyframes" if removed_any else "Nothing to clear on wheel objects.")
+                    "Cleared wheel drivers and rotation keyframes."
+                    if removed_any else "Nothing to clear on configured wheels.")
         return {'FINISHED'}
 
 # ---------------------- CSV Export ----------------------
 class SG_OT_ExportCSV(bpy.types.Operator):
-    bl_idname="segway.export_csv"; bl_label="Export CSV"
-    bl_description="Export t, x, y, yaw, thetaR/L, rateR/L using chosen sampling and units"
+    bl_idname = "segway.export_csv"
+    bl_label = "Export CSV"
+    bl_description = "Export t, x, y, yaw, thetaR/L (and thetaC on 3-wheel), rateR/L using chosen sampling and units"
+
     def execute(self, context):
-        P=context.scene.sg_props; d=bpy.app.driver_namespace.get(_driver_key())
-        if not d: self.report({'ERROR'}, "Build Cache first (and pass validation)."); return {'CANCELLED'}
-        path=bpy.path.abspath(P.csv_path)
-        fps=d['fps']; n=len(d['thetaL'])
-        ang_k=(1.0 if P.angle_unit=='RAD' else 180.0/pi)
-        if   P.angrate_unit=='RPM': rate_k=60.0/(2.0*pi)
-        elif P.angrate_unit=='RPS': rate_k=1.0/(2.0*pi)
-        else:                        rate_k=180.0/pi
-        len_k=(1.0 if P.length_unit=='M' else 100.0)
-        rows=[]
-        if P.sample_mode=='FRAME':
+        P = context.scene.sg_props
+        d = bpy.app.driver_namespace.get(_driver_key())
+        if not d:
+            self.report({'ERROR'}, "Build Cache first (and pass validation)."); return {'CANCELLED'}
+
+        include_c = d.get('num_wheels', 2) == 3
+        path = bpy.path.abspath(P.csv_path)
+        fps = d['fps']; n = len(d['thetaL'])
+        ang_k  = 1.0 if P.angle_unit == 'RAD' else 180.0 / pi
+        yaw_k  = 180.0 / pi if P.angle_unit == 'DEG' else 1.0
+        if   P.angrate_unit == 'RPM': rate_k = 60.0 / (2.0 * pi)
+        elif P.angrate_unit == 'RPS': rate_k = 1.0 / (2.0 * pi)
+        else:                          rate_k = 180.0 / pi
+        len_k = 1.0 if P.length_unit == 'M' else 100.0
+
+        # Convert cached VISUAL thetas (about the wheel's local axis, used by
+        # drivers) into PHYSICAL forward-roll thetas by multiplying with each
+        # wheel's sign. Result: positive theta / positive rate means the wheel
+        # is rolling forward, independently of how the wheel model is oriented.
+        sL = float(d.get('signL', 1.0))
+        sR = float(d.get('signR', 1.0))
+        sC = float(d.get('signC', 1.0))
+        thL_phys = [t * sL for t in d['thetaL']]
+        thR_phys = [t * sR for t in d['thetaR']]
+        thC_phys = [t * sC for t in d.get('thetaC', [0.0] * n)]
+
+        rows = []
+
+        if P.sample_mode == 'FRAME':
             for i in range(n):
-                t=i/fps
-                thL=d['thetaL'][i]; thR=d['thetaR'][i]
-                x=d['x'][i]*len_k; y=d['y'][i]*len_k
-                yaw=d['yaw'][i]*(180.0/pi if P.angle_unit=='DEG' else 1.0)
-                if i==0: rateR=rateL=0.0
+                t   = i / fps
+                thR = thR_phys[i]; thL = thL_phys[i]; thC = thC_phys[i]
+                x   = d['x'][i] * len_k; y = d['y'][i] * len_k
+                yaw = d['yaw'][i] * yaw_k
+                if i == 0:
+                    rateR = rateL = rateC = 0.0
                 else:
-                    dthR=d['thetaR'][i]-d['thetaR'][i-1]
-                    dthL=d['thetaL'][i]-d['thetaL'][i-1]
-                    rateR=(dthR*fps)*rate_k; rateL=(dthL*fps)*rate_k
-                rows.append((t,x,y,yaw, thR*ang_k, thL*ang_k, rateR, rateL))
+                    rateR = (thR_phys[i] - thR_phys[i - 1]) * fps * rate_k
+                    rateL = (thL_phys[i] - thL_phys[i - 1]) * fps * rate_k
+                    rateC = (thC_phys[i] - thC_phys[i - 1]) * fps * rate_k
+                rows.append((t, x, y, yaw,
+                             thR * ang_k, thL * ang_k, thC * ang_k,
+                             rateR, rateL, rateC))
         else:
-            try: hz=float(P.fixed_rate)
-            except: hz=100.0
-            hz=max(1.0,hz); dt=1.0/hz; total=(n-1)/fps; k=0
+            try: hz = float(P.fixed_rate)
+            except Exception: hz = 100.0
+            hz = max(1.0, hz); dt = 1.0 / hz
+            total = (n - 1) / fps; k = 0
             while True:
-                t=k*dt
-                if t>total+1e-9: break
-                idx=t*fps
-                thR=_linerp(d['thetaR'],idx); thL=_linerp(d['thetaL'],idx)
-                x=_linerp(d['x'],idx)*len_k; y=_linerp(d['y'],idx)*len_k
-                yaw=_linerp(d['yaw'],idx)*(180.0/pi if P.angle_unit=='DEG' else 1.0)
-                if k==0: rateR=rateL=0.0
+                t = k * dt
+                if t > total + 1e-9: break
+                idx = t * fps
+                thR = _linerp(thR_phys, idx)
+                thL = _linerp(thL_phys, idx)
+                thC = _linerp(thC_phys, idx)
+                x   = _linerp(d['x'], idx) * len_k
+                y   = _linerp(d['y'], idx) * len_k
+                yaw = _linerp(d['yaw'], idx) * yaw_k
+                if k == 0:
+                    rateR = rateL = rateC = 0.0
                 else:
-                    thRprev=rows[-1][4]/ang_k; thLprev=rows[-1][5]/ang_k
-                    rateR=((thR-thRprev)/dt)*rate_k; rateL=((thL-thLprev)/dt)*rate_k
-                rows.append((t,x,y,yaw, thR*ang_k, thL*ang_k, rateR, rateL))
-                k+=1
+                    thRprev = rows[-1][4] / ang_k
+                    thLprev = rows[-1][5] / ang_k
+                    thCprev = rows[-1][6] / ang_k
+                    rateR = ((thR - thRprev) / dt) * rate_k
+                    rateL = ((thL - thLprev) / dt) * rate_k
+                    rateC = ((thC - thCprev) / dt) * rate_k
+                rows.append((t, x, y, yaw,
+                             thR * ang_k, thL * ang_k, thC * ang_k,
+                             rateR, rateL, rateC))
+                k += 1
+
+        au = P.angle_unit.lower()
+        ru = P.angrate_unit.lower()
+        xu = 'x_m' if P.length_unit == 'M' else 'x_cm'
+        yu = 'y_m' if P.length_unit == 'M' else 'y_cm'
+
         try:
-            with open(path,"w",encoding="utf-8") as f:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("# theta/rate are PHYSICAL forward-roll values: "
+                        "positive = wheel rolls forward.\n")
                 f.write("# Track width is center-to-center of left/right wheels.\n")
-                f.write(f"# track_width_m={P.track_width:.6f}, tire_spacing_m={P.tire_spacing:.6f}, swap_lr={P.swap_lr}, wheel_forward_invert={P.wheel_forward_invert}\n")
-                f.write(f"t,{('x_m' if P.length_unit=='M' else 'x_cm')},{('y_m' if P.length_unit=='M' else 'y_cm')},yaw_{P.angle_unit.lower()},thetaR_{P.angle_unit.lower()},thetaL_{P.angle_unit.lower()},rateR_{P.angrate_unit.lower()},rateL_{P.angrate_unit.lower()}\n")
-                for r in rows:
-                    f.write("{:.6f},{:.6f},{:.6f},{:.9f},{:.9f},{:.9f},{:.4f},{:.4f}\n".format(*r))
+                f.write(f"# num_wheels={d.get('num_wheels', 2)}, "
+                        f"track_width_m={d.get('track', 0.0):.6f}, "
+                        f"swap_lr={P.swap_lr}\n")
+                if include_c:
+                    f.write(f"t,{xu},{yu},yaw_{au},thetaR_{au},thetaL_{au},thetaC_{au},"
+                            f"rateR_{ru},rateL_{ru},rateC_{ru}\n")
+                    fmt = "{:.6f},{:.6f},{:.6f},{:.9f},{:.9f},{:.9f},{:.9f},{:.4f},{:.4f},{:.4f}\n"
+                    for r in rows:
+                        f.write(fmt.format(*r))
+                else:
+                    f.write(f"t,{xu},{yu},yaw_{au},thetaR_{au},thetaL_{au},rateR_{ru},rateL_{ru}\n")
+                    fmt = "{:.6f},{:.6f},{:.6f},{:.9f},{:.9f},{:.9f},{:.4f},{:.4f}\n"
+                    for r in rows:
+                        # Drop thetaC (index 6) and rateC (index 9).
+                        f.write(fmt.format(r[0], r[1], r[2], r[3], r[4], r[5], r[7], r[8]))
         except Exception as e:
             self.report({'ERROR'}, f"Failed to write CSV: {e}"); return {'CANCELLED'}
-        self.report({'INFO'}, f"Wrote {path} ({len(rows)} samples)"); return {'FINISHED'}
+        self.report({'INFO'}, f"Wrote {path} ({len(rows)} samples).")
+        return {'FINISHED'}
 
 # ---------------------- CSV Import ----------------------
 class SG_OT_ImportCSV(bpy.types.Operator):
@@ -1130,10 +2116,10 @@ class SG_OT_ImportCSV(bpy.types.Operator):
         if not ch:
             self.report({'ERROR'}, "Assign the Chassis first."); return {'CANCELLED'}
         
-        # Get selected objects for wheel collections
-        colL=_col_for_side(P,'L'); colR=_col_for_side(P,'R')
-        if not colL or not colR:
-            self.report({'ERROR'}, "Assign Left and Right wheel collections first."); return {'CANCELLED'}
+        # Require at least one wheel per side for tire animation to have a target.
+        if not _iter_side(P, 'L') or not _iter_side(P, 'R'):
+            self.report({'ERROR'}, "Assign at least Left Wheel 01 and Right Wheel 01 before importing.")
+            return {'CANCELLED'}
         
         path=bpy.path.abspath(P.csv_import_path)
         if not path or not os.path.exists(path):
@@ -1159,11 +2145,6 @@ class SG_OT_ImportCSV(bpy.types.Operator):
             # Parse header row (first data row)
             header = data_rows[0]
             data_rows = data_rows[1:]  # Remove header from data
-            
-            # Debug: Show what we're working with
-            self.report({'INFO'}, f"CSV has {len(rows)} total rows, skipping {skip_rows}, using {len(data_rows)} data rows")
-            self.report({'INFO'}, f"Header row: {header}")
-            self.report({'INFO'}, f"First few data rows: {data_rows[:3] if len(data_rows) >= 3 else data_rows}")
             
             # Find column indices - match your actual CSV format
             col_indices = {}
@@ -1210,9 +2191,8 @@ class SG_OT_ImportCSV(bpy.types.Operator):
                     col_indices['thetaR'] = i
                 elif col_name == 'thetal':
                     col_indices['thetaL'] = i
-            
-            # Debug: Show what columns we found
-            self.report({'INFO'}, f"Found columns: {col_indices}")
+                elif col_name in ('thetac', 'thetac_rad'):
+                    col_indices['thetaC'] = i
             
             # Check required columns - your CSV format has t, x_m, y_m, yaw_rad
             required_cols = ['frame', 'x', 'y']  # z is optional, yaw_rad is rotation
@@ -1223,31 +2203,28 @@ class SG_OT_ImportCSV(bpy.types.Operator):
                 self.report({'ERROR'}, f"Try adjusting 'Skip Rows from Top' setting (currently {skip_rows})")
                 return {'CANCELLED'}
             
-            # Clear existing animation on chassis
-            if ch.animation_data and ch.animation_data.action:
-                for fc in list(ch.animation_data.action.fcurves):
-                    if fc.data_path in ("location", "rotation_euler", "rotation_quaternion"):
-                        try: ch.animation_data.action.fcurves.remove(fc)
-                        except Exception: pass
-            
-            # Create new action if needed
-            if not ch.animation_data:
-                ch.animation_data_create()
-            if not ch.animation_data.action:
-                ch.animation_data.action = bpy.data.actions.new(name="ImportedAnimation")
-            
+            # Ensure action + slot, then clear existing chassis animation
+            act = _ensure_action_for(ch, action_name="ImportedAnimation")
+            for fc in list(_iter_action_fcurves(act)):
+                if fc.data_path in ("location", "rotation_euler", "rotation_quaternion"):
+                    _remove_action_fcurve(act, fc)
+
+            # Use the scene's FPS and start frame so time columns align with
+            # the current scene, not with an arbitrary 30 FPS / frame-1 origin.
+            scn = context.scene
+            scene_fps = scn.render.fps / max(1e-9, scn.render.fps_base)
+            base_frame = int(scn.frame_start)
+
             # Process data rows
             frames_processed = 0
             for row in data_rows:
                 if len(row) <= max(col_indices.values()):
                     continue  # Skip incomplete rows
-                
+
                 try:
-                    # Parse frame number (t column in your CSV contains time in seconds)
+                    # Parse frame number (t column in CSV contains time in seconds)
                     time_seconds = float(row[col_indices['frame']])
-                    # Convert time to frame number (assuming 30 FPS, adjust if needed)
-                    fps = 30.0  # You can make this configurable later
-                    frame = int(round(time_seconds * fps)) + 1  # +1 to start from frame 1
+                    frame = int(round(time_seconds * scene_fps)) + base_frame
                     
                     # Parse position
                     x = float(row[col_indices['x']])
@@ -1293,13 +2270,21 @@ class SG_OT_ImportCSV(bpy.types.Operator):
                 except (ValueError, IndexError) as e:
                     continue  # Skip invalid rows
             
-            # Apply tire rotation to wheel objects if thetaR/thetaL columns exist
+            # Apply tire rotation to wheel objects if thetaR / thetaL columns exist.
+            # thetaC is applied to the caster if the 3-wheel config is active
+            # and a thetaC column is present.
             if 'thetaR' in col_indices and 'thetaL' in col_indices:
                 axis_i = _AXIS_INDEX[P.wheel_axis]
                 ux, uy, uz = _axis_unit(P.wheel_axis)
-                
-                # Clear existing wheel animation
-                for side in ('L', 'R'):
+
+                sides_present = ['L', 'R']
+                if _wheel_count(P) == 3 and 'thetaC' in col_indices and _iter_side(P, 'C'):
+                    sides_present.append('C')
+
+                # Clear existing wheel animation and capture each wheel's rest
+                # quaternion ONCE so subsequent spin composition doesn't drift.
+                wheel_rest = {}  # id(obj) -> (w,x,y,z)
+                for side in sides_present:
                     for obj in _iter_side(P, side):
                         if P.rotation_mode == 'EULER':
                             _ensure_xyz_euler(obj)
@@ -1310,74 +2295,53 @@ class SG_OT_ImportCSV(bpy.types.Operator):
                             try:
                                 for i in range(4): obj.driver_remove("rotation_quaternion", i)
                             except Exception: pass
-                        
-                        # Clear keyframes
+
                         ad = obj.animation_data
                         if ad and ad.action:
-                            to_del = [fc for fc in ad.action.fcurves
+                            to_del = [fc for fc in _iter_action_fcurves(ad.action)
                                     if (fc.data_path == "rotation_euler" and fc.array_index == axis_i)
                                     or fc.data_path == "rotation_quaternion"]
                             for fc in to_del:
-                                try: ad.action.fcurves.remove(fc)
-                                except Exception: pass
-                
+                                _remove_action_fcurve(ad.action, fc)
+
+                        wheel_rest[id(obj)] = _obj_rest_quat(obj)
+
                 # Apply tire rotations
                 for row in data_rows:
                     if len(row) <= max(col_indices.values()):
                         continue
-                    
+
                     try:
-                        # Convert time to frame number (same logic as above)
                         time_seconds = float(row[col_indices['frame']])
-                        fps = 30.0
-                        frame = int(round(time_seconds * fps)) + 1
-                        thetaR = float(row[col_indices['thetaR']])
-                        thetaL = float(row[col_indices['thetaL']])
-                        
-                        # Apply to right wheels
-                        for obj in _iter_side(P, 'R'):
-                            if P.rotation_mode == 'EULER':
-                                obj.rotation_euler[axis_i] = thetaR
-                                obj.keyframe_insert("rotation_euler", frame=frame, index=axis_i)
-                            else:
-                                # Quaternion rotation
-                                half = 0.5 * thetaR
-                                s = sin(half); c = cos(half)
-                                q_spin = (c, ux*s, uy*s, uz*s)
-                                rest = _obj_rest_quat(obj)
-                                aw, ax, ay, az = rest
-                                bw, bx, by, bz = q_spin
-                                q = (aw*bw-ax*bx-ay*by-az*bz,
-                                     aw*bx+ax*bw+ay*bz-az*by,
-                                     aw*by-ax*bz+ay*bw+az*bx,
-                                     aw*bz+ax*by-ay*bx+az*bw)
-                                rq = obj.rotation_quaternion
-                                rq[0], rq[1], rq[2], rq[3] = q
-                                for comp in range(4):
-                                    obj.keyframe_insert("rotation_quaternion", frame=frame, index=comp)
-                        
-                        # Apply to left wheels
-                        for obj in _iter_side(P, 'L'):
-                            if P.rotation_mode == 'EULER':
-                                obj.rotation_euler[axis_i] = thetaL
-                                obj.keyframe_insert("rotation_euler", frame=frame, index=axis_i)
-                            else:
-                                # Quaternion rotation
-                                half = 0.5 * thetaL
-                                s = sin(half); c = cos(half)
-                                q_spin = (c, ux*s, uy*s, uz*s)
-                                rest = _obj_rest_quat(obj)
-                                aw, ax, ay, az = rest
-                                bw, bx, by, bz = q_spin
-                                q = (aw*bw-ax*bx-ay*by-az*bz,
-                                     aw*bx+ax*bw+ay*bz-az*by,
-                                     aw*by-ax*bz+ay*bw+az*bx,
-                                     aw*bz+ax*by-ay*bx+az*bw)
-                                rq = obj.rotation_quaternion
-                                rq[0], rq[1], rq[2], rq[3] = q
-                                for comp in range(4):
-                                    obj.keyframe_insert("rotation_quaternion", frame=frame, index=comp)
-                    
+                        frame = int(round(time_seconds * scene_fps)) + base_frame
+                        thetas = {
+                            'L': float(row[col_indices['thetaL']]),
+                            'R': float(row[col_indices['thetaR']]),
+                        }
+                        if 'C' in sides_present:
+                            thetas['C'] = float(row[col_indices['thetaC']])
+
+                        for side in sides_present:
+                            theta = thetas[side]
+                            half = 0.5 * theta
+                            s = sin(half); c = cos(half)
+                            q_spin = (c, ux*s, uy*s, uz*s)
+                            for obj in _iter_side(P, side):
+                                if P.rotation_mode == 'EULER':
+                                    obj.rotation_euler[axis_i] = theta
+                                    obj.keyframe_insert("rotation_euler", frame=frame, index=axis_i)
+                                else:
+                                    aw, ax, ay, az = wheel_rest.get(id(obj), (1.0, 0.0, 0.0, 0.0))
+                                    bw, bx, by, bz = q_spin
+                                    q = (aw*bw - ax*bx - ay*by - az*bz,
+                                         aw*bx + ax*bw + ay*bz - az*by,
+                                         aw*by - ax*bz + ay*bw + az*bx,
+                                         aw*bz + ax*by - ay*bx + az*bw)
+                                    rq = obj.rotation_quaternion
+                                    rq[0], rq[1], rq[2], rq[3] = q
+                                    for comp in range(4):
+                                        obj.keyframe_insert("rotation_quaternion", frame=frame, index=comp)
+
                     except (ValueError, IndexError):
                         continue
             
@@ -1392,7 +2356,7 @@ class SG_OT_ImportCSV(bpy.types.Operator):
 def _collect_keyframes(obj,fmin,fmax):
     frames=set(); ad=obj.animation_data
     if ad and ad.action:
-        for fc in ad.action.fcurves:
+        for fc in _iter_action_fcurves(ad.action):
             if fc.data_path in ("location","rotation_euler","rotation_quaternion"):
                 for kp in fc.keyframe_points:
                     fr=int(round(kp.co[0]))
@@ -1435,7 +2399,7 @@ class SG_OT_ExportKeyframes(bpy.types.Operator):
                     for r in rows:
                         f.write("{frame},{fps:.6f},{time_s:.6f},{x:.6f},{y:.6f},{z:.6f},{euler_x:.9f},{euler_y:.9f},{euler_z:.9f},{quat_w:.9f},{quat_x:.9f},{quat_y:.9f},{quat_z:.9f},{thetaR:.9f},{thetaL:.9f}\n".format(**r))
             else:
-                out={"meta":{"angle_unit":P.other_angle_unit,"fps":fps,"swap_lr":P.swap_lr,"wheel_forward_invert":P.wheel_forward_invert,
+                out={"meta":{"angle_unit":P.other_angle_unit,"fps":fps,"swap_lr":P.swap_lr,
                              "frame_start":int(scn.frame_start),"frame_end":int(scn.frame_end)},
                      "samples":rows}
                 with open(path,"w",encoding="utf-8") as f: json.dump(out,f,indent=2)
@@ -1445,108 +2409,147 @@ class SG_OT_ExportKeyframes(bpy.types.Operator):
 
 # ---------------------- UI ----------------------
 class SG_PT_Panel(bpy.types.Panel):
-    bl_label="True RoboAnimator"
-    bl_space_type='VIEW_3D'
-    bl_region_type='UI'
-    bl_category="True RoboAnimator"
+    bl_label = "True RoboAnimator"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = "True RoboAnimator"
 
-    def _section(self, layout, prop_flag, title):
-        box=layout.box(); header=box.row(); P=bpy.context.scene.sg_props
-        is_open=getattr(P,prop_flag); icon='TRIA_DOWN' if is_open else 'TRIA_RIGHT'
-        header.prop(P, prop_flag, text="", icon=icon, emboss=False)
-        header.label(text=title)
-        return box if is_open else None
+    def _section(self, layout, P, flag, title, icon='NONE'):
+        """Collapsible section. Returns the inner column when open, else None."""
+        box = layout.box()
+        row = box.row(align=True)
+        is_open = getattr(P, flag)
+        row.prop(P, flag, text="",
+                 icon='TRIA_DOWN' if is_open else 'TRIA_RIGHT',
+                 emboss=False)
+        row.label(text=title, icon=icon)
+        return box.column() if is_open else None
 
     def draw(self, context):
-        layout=self.layout; P=context.scene.sg_props
-        layout.use_property_split=True; layout.use_property_decorate=False
+        layout = self.layout
+        P = context.scene.sg_props
+        layout.use_property_split = True
+        layout.use_property_decorate = False
 
-        box = self._section(layout, "show_instructions", "Instructions")
-        if box:
-            c = box.column(align=True)
-            c.label(text="1) Animate chassis (location + rotation).")
-            c.label(text="2) Validate Motion (no sideways slip).")
-            c.label(text="3) Autocorrect: S-Curve or Linear.")
-            c.label(text="4) Pick Speed Profile (Constant+ramps / Ease Whole / Per Segment).")
-            c.label(text="5) Build Cache → Attach Drivers (or Bake Wheels).")
-            c.label(text="6) Export (keyframes / CSV).")
-            c.label(text="Tip: If wheels roll backwards, toggle Wheel Forward Invert or swap L/R.")
+        # ---- How to Use ----
+        col = self._section(layout, P, "show_instructions", "How to Use", icon='HELP')
+        if col:
+            c = col.column(align=True)
+            c.label(text="1. Assign chassis and wheels.")
+            c.label(text="2. Keyframe chassis motion.")
+            c.label(text="3. Validate, then Autocorrect.")
+            c.label(text="4. Build Cache, then Attach Drivers or Bake.")
+            c.label(text="5. Export.")
 
-        box=self._section(layout, "show_selection", "Object Selection")
-        if box:
-            col=box.column(align=True)
-            col.prop(P,"chassis")
-            col.prop(P,"right_collection")
-            col.prop(P,"left_collection")
-            col.prop(P,"swap_lr")
+        # ---- Viewport Helpers (near the top so it's easy to find) ----
+        col = self._section(layout, P, "show_viewport", "Viewport Helpers", icon='OVERLAY')
+        if col:
+            col.prop(P, "vis_enabled")
+            sub = col.column(align=True)
+            sub.enabled = P.vis_enabled
+            sub.prop(P, "vis_show_forward")
+            sub.prop(P, "vis_show_wheels")
+            sub.prop(P, "vis_show_raw_path")
+            sub.prop(P, "vis_show_solution_path")
 
-        box=self._section(layout, "show_calibration", "Calibration & Wheel Setup")
-        if box:
-            col=box.column(align=True)
-            col.label(text="Geometry (meters)")
-            col.prop(P,"track_width")
-            col.prop(P,"tire_spacing")
-            col.prop(P,"auto_radius")
-            if not P.auto_radius: col.prop(P,"wheel_radius")
-            col.separator(); col.label(text="Wheel Rotation")
-            col.prop(P,"wheel_axis"); col.prop(P,"rotation_mode")
-            col.prop(P,"sign_r"); col.prop(P,"sign_l")
-            col.prop(P,"wheel_forward_invert")
-
-        box=self._section(layout, "show_csv_import", "Import Animation by CSV")
-        if box:
-            col=box.column(align=True)
-            col.prop(P,"csv_import_path")
-            col.prop(P,"csv_import_skip_rows")
+        # ---- Rig Setup ----
+        col = self._section(layout, P, "show_setup", "Rig Setup", icon='OUTLINER_OB_ARMATURE')
+        if col:
+            col.prop(P, "chassis")
             col.separator()
-            col.label(text="Imports chassis position/rotation and tire rotation")
-            col.label(text="from CSV with columns: frame, x, y, z, thetaR, thetaL")
-            col.label(text="(and optionally euler_x/y/z or quat_w/x/y/z)")
-            box.operator("segway.import_csv", icon='IMPORT')
+            col.prop(P, "num_wheels", expand=True)
+            col.separator()
+            n = _wheel_count(P)
+            g = col.column(align=True)
+            g.prop(P, "wheel_l_01")
+            if n >= 4: g.prop(P, "wheel_l_02")
+            if n == 6: g.prop(P, "wheel_l_03")
+            g.prop(P, "wheel_r_01")
+            if n >= 4: g.prop(P, "wheel_r_02")
+            if n == 6: g.prop(P, "wheel_r_03")
+            if n == 3: g.prop(P, "wheel_caster")
+            col.separator()
+            col.prop(P, "swap_lr")
 
-        box=self._section(layout, "show_feasibility", "Feasibility & Autocorrect")
-        if box:
-            col=box.column(align=True)
+        # ---- Calibration ----
+        col = self._section(layout, P, "show_calibration", "Calibration", icon='DRIVER_DISTANCE')
+        if col:
+            col.prop(P, "auto_track_width")
+            r = col.row(); r.enabled = not P.auto_track_width
+            r.prop(P, "track_width")
+            if P.auto_track_width:
+                col.label(text=f"Auto: {_effective_track_width(P):.4f} m", icon='INFO')
+            col.separator()
+            col.prop(P, "auto_radius")
+            if not P.auto_radius:
+                col.prop(P, "wheel_radius")
+            col.separator()
+            col.prop(P, "wheel_axis")
+            col.prop(P, "rotation_mode")
+
+        # ---- Motion Path ----
+        col = self._section(layout, P, "show_motion", "Motion Path", icon='CURVE_BEZCURVE')
+        if col:
             col.prop(P, "body_forward_axis")
             col.prop(P, "side_tol")
+            col.separator()
             col.prop(P, "autocorrect_mode")
-            col.prop(P, "bezier_tangent_scale")
-            col.prop(P, "linear_rotation_fraction")
+            r = col.row(); r.enabled = (P.autocorrect_mode == 'SEASE')
+            r.prop(P, "bezier_tangent_start")
+            r = col.row(); r.enabled = (P.autocorrect_mode == 'SEASE')
+            r.prop(P, "bezier_tangent_end")
+            r = col.row(); r.enabled = (P.autocorrect_mode == 'LINEAR')
+            r.prop(P, "linear_rotation_fraction")
+            col.separator()
             col.prop(P, "speed_profile")
-            rC=col.row(align=True); rC.enabled=(P.speed_profile=='CONSTANT'); rC.prop(P,"constant_ramp_frames")
-            r=col.row(align=True); r.enabled=(P.speed_profile=='GLOBAL_EASE'); r.prop(P,"timeline_ease_frames")
-            rS=col.row(align=True); rS.enabled=(P.speed_profile=='PER_KEY_EASE'); rS.prop(P,"segment_ease_frames")
-            row=box.row(align=True)
-            row.operator("segway.validate_motion", icon='INFO')
-            row.operator("segway.autocorrect_bake", icon='MOD_CURVE')
-            box.operator("segway.revert_autocorrect", icon='LOOP_BACK')
+            r = col.row(); r.enabled = (P.speed_profile == 'CONSTANT')
+            r.prop(P, "constant_ramp_frames")
+            r = col.row(); r.enabled = (P.speed_profile == 'GLOBAL_EASE')
+            r.prop(P, "timeline_ease_frames")
+            r = col.row(); r.enabled = (P.speed_profile == 'PER_KEY_EASE')
+            r.prop(P, "segment_ease_frames")
+            col.separator()
+            r = col.row(align=True)
+            r.operator("segway.validate_motion",  icon='CHECKMARK')
+            r.operator("segway.autocorrect_bake", icon='MOD_CURVE')
+            col.operator("segway.revert_autocorrect", icon='LOOP_BACK')
 
-        box=self._section(layout, "show_rpm_calc", "RPM Calculation & Limits")
-        if box:
-            lim=box.box().column(align=True)
-            lim.prop(P,"max_rpm")
-            lim.prop(P,"max_ang_accel_rpm_s")
-            row=box.row(align=True)
-            row.operator("segway.build_cache", icon='IMPORT')
-            row.operator("segway.attach_drivers", icon='CONSTRAINT')
-            row=box.row(align=True)
-            row.operator("segway.bake_wheels", icon='REC')
-            row.operator("segway.clear", icon='TRASH')
+        # ---- Wheel Drivers ----
+        col = self._section(layout, P, "show_drivers", "Wheel Drivers", icon='DRIVER')
+        if col:
+            col.prop(P, "max_rpm")
+            col.prop(P, "max_ang_accel_rpm_s")
+            col.separator()
+            r = col.row(align=True)
+            r.operator("segway.build_cache",    icon='FILE_REFRESH')
+            r.operator("segway.attach_drivers", icon='CONSTRAINT')
+            r = col.row(align=True)
+            r.operator("segway.bake_wheels", icon='REC')
+            r.operator("segway.clear",       icon='TRASH')
 
-        box=self._section(layout, "show_anim_export", "Animation Data Export (Keyframes)")
-        if box:
-            f=box.box(); f.prop(P,"other_export_path")
-            o=box.box(); o.prop(P,"other_export_format"); o.prop(P,"other_angle_unit")
-            r=box.box(); r.operator("segway.export_keyframes", icon='EXPORT')
-
-        box=self._section(layout, "show_csv_export", "CSV Engineering Export")
-        if box:
-            f=box.box(); f.prop(P,"csv_path")
-            opts=box.box().column(align=True)
-            opts.prop(P,"sample_mode")
-            if P.sample_mode=='FIXED': opts.prop(P,"fixed_rate")
-            opts.prop(P,"angle_unit"); opts.prop(P,"angrate_unit"); opts.prop(P,"length_unit")
-            run=box.box(); run.operator("segway.export_csv", icon='EXPORT')
+        # ---- Import / Export (combined) ----
+        col = self._section(layout, P, "show_io", "Import / Export", icon='FILE_TICK')
+        if col:
+            col.prop(P, "io_mode", expand=True)
+            col.separator()
+            if P.io_mode == 'IMPORT':
+                col.prop(P, "csv_import_path",      text="File")
+                col.prop(P, "csv_import_skip_rows", text="Skip Rows")
+                col.operator("segway.import_csv", icon='IMPORT')
+            elif P.io_mode == 'KEYS':
+                col.prop(P, "other_export_path",   text="File")
+                col.prop(P, "other_export_format", text="Format")
+                col.prop(P, "other_angle_unit",    text="Angle")
+                col.operator("segway.export_keyframes", icon='EXPORT')
+            else:  # 'CSV'
+                col.prop(P, "csv_path",     text="File")
+                col.prop(P, "sample_mode",  text="Sampling")
+                if P.sample_mode == 'FIXED':
+                    col.prop(P, "fixed_rate", text="Rate")
+                col.prop(P, "angle_unit",   text="Angle")
+                col.prop(P, "angrate_unit", text="Angular Rate")
+                col.prop(P, "length_unit",  text="Length")
+                col.operator("segway.export_csv", icon='EXPORT')
 
 # ---------------------- register / unregister ----------------------
 classes=(
@@ -1567,15 +2570,20 @@ classes=(
 )
 
 def register():
-    for c in classes: bpy.utils.register_class(c)
-    bpy.types.Scene.sg_props=bpy.props.PointerProperty(type=SG_Props)
-    bpy.app.driver_namespace['sg_theta']=sg_theta
-    bpy.app.driver_namespace['sg_quat_comp']=sg_quat_comp
-    bpy.app.driver_namespace['sg_quat_comp_obj']=sg_quat_comp_obj
+    for c in classes:
+        bpy.utils.register_class(c)
+    bpy.types.Scene.sg_props = bpy.props.PointerProperty(type=SG_Props)
+    bpy.app.driver_namespace['sg_theta'] = sg_theta
+    bpy.app.driver_namespace['sg_quat_comp'] = sg_quat_comp
+    bpy.app.driver_namespace['sg_quat_comp_obj'] = sg_quat_comp_obj
+    _register_draw_handler()
+    _tag_viewport_redraw()
 
 def unregister():
-    for c in reversed(classes): bpy.utils.unregister_class(c)
-    for k in ('sg_theta','sg_quat_comp','sg_quat_comp_obj', _driver_key()):
+    _unregister_draw_handler()
+    for c in reversed(classes):
+        bpy.utils.unregister_class(c)
+    for k in ('sg_theta', 'sg_quat_comp', 'sg_quat_comp_obj', _driver_key()):
         bpy.app.driver_namespace.pop(k, None)
     del bpy.types.Scene.sg_props
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,12 +1,13 @@
 schema_version = "1.0.0"
 
 id = "true_roboanimator"
-version = "1.0.0"
+version = "1.4.1"
 name = "True RoboAnimator"
-tagline = "Robot motion to wheel RPM with CSV export"
+tagline = "Chassis motion to per-wheel RPM (2/3/4/6-wheel configs) with CSV export"
 maintainer = "Danyal S."
 type = "add-on"
 
+# Runs on the current 4.2 LTS line and the 5.0 series.
 blender_version_min = "4.2.0"
 
 license = ["SPDX:GPL-3.0-or-later"]


### PR DESCRIPTION
## Summary

This PR takes the addon from **v1.0.0 to v1.4.1** with Blender 5.0 support, a live-updating viewport overlay, 2 / 3 / 4 / 6-wheel configurations, auto-detected calibration, and correctness fixes across the kinematics + CSV pipeline.

## Blender 4.4+ / 5.0 compatibility

- Added missing top-level imports (\`bpy\`, \`os\`, \`json\`, \`bisect\`, \`math\`, \`mathutils\`) that prevented the module from loading in any Blender build.
- Wrapped every Action fcurve access in a compat layer that walks \`layers -> strips -> channelbags\` so slotted actions (Blender 4.4+) work for reads, writes, backups, and CSV import.
- Fresh actions now auto-get a slot bound to the target object so \`keyframe_insert\` actually stores data.

## Wheel configurations

- New **Wheel Configuration** enum: **2 (Diff Drive)**, **3 (Diff + Caster)**, **4 (Skid Steer)**, **6 (Rocker / Rover)**.
- Individual pointer slots replace the old collection pickers: \`Left Wheel 01/02/03\`, \`Right Wheel 01/02/03\`, and \`Caster Wheel\`. Only slots relevant to the current config are shown.
- 3-wheel adds a passive caster that rolls off chassis forward motion only (\`ds_C = dx\`, no yaw contribution); its own \`thetaC\`, \`restC\`, driver expression, and CSV column are tracked separately.
- 4- and 6-wheel skid-steer replicate the per-side angle to every wheel on that side; kinematics stays diff-drive with \`track_width\` as \`b\`.

## Viewport helpers (GPU draw handler)

Overlays drawn as construction lines in every 3D View, always visible through geometry:

- **Body forward** - green arrow along the current Body Forward Axis.
- **Wheel rotation axes** - colored axis lines through each configured wheel (L red, R blue, caster yellow) with a small tick at the positive-theta end. Length ~ 2 x tire width.
- **Raw path** - orange polyline with waypoint dots. Uses the autocorrect backup when it exists so the user's original intent stays visible after a bake.
- **Solution path** - cyan **live preview**. Samples the S-Ease Bezier geometry directly or renders a piecewise-linear polyline for Linear mode. Responds to \`Autocorrect Mode\`, \`Tangent Scale Start / End\`, \`Body Forward Axis\`, and wheel-related settings **instantly**, without needing a bake.

Every setting that affects what's drawn carries \`update=_tag_viewport_redraw\`, so panel changes redraw every 3D view immediately.

## Auto-detected calibration

- **Wheel rolling direction** derived per wheel from world axis vs body forward at \`frame_start\` (rolling-without-slip constraint: \`sign((A x up) . body_fwd)\`).
- **Wheel Rotation Axis** auto-set perpendicular to Body Forward Axis whenever the latter changes.
- **Track Width** auto-measured as the world distance between \`wheel_l_01\` and \`wheel_r_01\` when \`Auto Track Width\` is on.
- **Assigning chassis or wheels** bakes rotation and scale into the mesh via \`mesh.transform()\` with safety guards: mesh objects only, unparented, single-user mesh, no existing animation, Object mode, not already identity.

## CSV pipeline

- Cache stores per-wheel signs (\`signL\`, \`signR\`, \`signC\`) alongside the theta arrays.
- \`SG_OT_ExportCSV\` multiplies visual thetas by their signs so CSV rows are **physical forward-roll values** (positive = wheel rolls forward, matching robotics convention). This fixes the reported \"L/R switched\" behavior on mirrored rigs.
- 3-wheel configs emit \`thetaC_*\` / \`rateC_*\` columns.
- CSV import now uses **scene FPS and start frame** instead of hard-coded 30 FPS and frame 1.
- Header comment documents the physical-forward-roll convention.

## Correctness fixes

- **Inverted wheel sign auto-detect** (crossed with \`down\` instead of \`up\` - every wheel was rolling backwards). Verified from the rolling-without-slip derivation.
- **Cumulative quaternion drift in CSV import** - \`_obj_rest_quat\` was being re-read after each write, compounding rotations. Now captured once per wheel before the row loop.
- \`SG_OT_Bake\` was applying the first wheel's rest to every wheel in the collection; now captures per-wheel rest, matching \`SG_OT_AttachDrivers\`.
- \`build_cache\` had \`dx = -dx\` inside the loop that cancelled the \`signL / signR\` flip for translation while leaving yaw inverted; removed.
- \`_edge_ease_progress\` docstring claimed C1 but the profile is C0 only; corrected.

## Motion path tuning

- **Tangent Scale split** into \`Tangent Scale Start\` (P1 handle) and \`Tangent Scale End\` (P2 handle) for asymmetric S-curves.
- Removed the \`5 * rho\` cap (max L = 2.5 x track_width, which saturated the slider immediately) and the iterative curvature-shrink loop. Tangent Scale now maps directly to handle length, capped only at \`0.49 * chord_distance\` to keep curves from folding back on themselves.

## Panel redesign

- Numbered stage titles replaced with flat headers; sub-boxes collapsed.
- **Viewport Helpers** moved to right under Instructions for discoverability.
- Import CSV / Export Keyframes / Engineering CSV merged into one **Import / Export** section with a mode-tab enum.
- All em/en dashes removed from UI strings, docstrings, and README.

## Removed

- \`tire_spacing\` (unused metadata; \`track_width\` is the real parameter).
- \`invert_wheels\` (auto-detect handles it; obsolete after sign fix).
- \`sign_l\` / \`sign_r\` / \`sign_c\` / \`wheel_forward_invert\` (replaced by auto-detect).

## Version

- \`bl_info\`, \`blender_manifest.toml\`, README all bumped **1.0.0 -> 1.4.1**.
- Blender support declared: **4.2 LTS through 5.0**.

## Test plan

- [ ] Install the packaged zip into Blender 4.2 LTS and confirm the panel loads and every section expands cleanly.
- [ ] Install into Blender 5.0 and confirm the same, plus that raw / solution paths render (this was the slotted-action symptom).
- [ ] Set up a 2-wheel rig: chassis + \`wheel_l_01\` + \`wheel_r_01\`. Confirm auto Track Width shows the correct value and wheel rotation axis snaps perpendicular to Body Forward Axis.
- [ ] Keyframe a curved chassis motion. Switch Autocorrect Mode between S-Ease and Linear and confirm the cyan solution path updates instantly.
- [ ] Slide Tangent Scale Start and Tangent Scale End independently up to 0.49 and confirm the S-curve reshapes both handles without plateauing.
- [ ] Run Autocorrect & Bake, then Build Cache + Attach Drivers. Play the timeline and confirm every wheel rolls forward during forward chassis motion, and that left rolls backward / right rolls forward during CCW yaw.
- [ ] Export Engineering CSV. Confirm \`rateL\` and \`rateR\` are both positive during forward motion, and that during CCW yaw \`rateL\` is negative and \`rateR\` is positive.
- [ ] Set Wheel Configuration to 3, assign a caster, rebuild the cache, and confirm the caster spins with forward motion but not during pure yaw.
- [ ] Assign a wheel with non-identity scale / rotation to a slot and confirm scale and rotation get baked into the mesh automatically.